### PR TITLE
Fix reconnection variables

### DIFF
--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -104,11 +104,11 @@ module.exports = function (RED: NodeRedApp): void {
 
 
       try {
-        const connection = await amqp.connect()
+        connection = await amqp.connect()
 
         // istanbul ignore else
         if (connection) {
-          const channel = await amqp.initialize()
+          channel = await amqp.initialize()
           await amqp.consume()
 
           // When the connection goes down

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -152,7 +152,7 @@ module.exports = function (RED: NodeRedApp): void {
       }
   
       try {
-        const connection = await amqp.connect()
+        connection = await amqp.connect()
 
         // istanbul ignore else
         if (connection) {


### PR DESCRIPTION
## Summary
- fix reconnect variable assignment for outgoing and manual-ack nodes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68401206d478832abce5c9cf3dea2e64