### PR TITLE
Add queue arguments support

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -373,7 +373,7 @@ export default class Amqp {
       autoDelete,
       arguments: {
         "x-queue-type": queueType,
-        ...queueArguments,
+        ...(queueArguments || {}),
       },
     })
 

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -2,7 +2,7 @@ import { NodeRedApp, Node } from 'node-red'
 import { v4 as uuidv4 } from 'uuid'
 import cloneDeep = require('lodash.clonedeep')
 import {
-  Connection,
+  ChannelModel,
   Channel,
   Replies,
   connect,
@@ -24,7 +24,7 @@ import { NODE_STATUS } from './constants'
 export default class Amqp {
   private config: AmqpConfig
   private broker: Node
-  private connection: Connection
+  private connection: ChannelModel
   private channel: Channel
   private q: Replies.AssertQueue
 
@@ -50,7 +50,8 @@ export default class Amqp {
         exclusive: config.queueExclusive,
         durable: config.queueDurable,
         autoDelete: config.queueAutoDelete,
-        queueType: config.queueType
+        queueType: config.queueType,
+        queueArguments: this.parseJson(config.queueArguments)
       },
       amqpProperties: this.parseJson(
         config.amqpProperties,
@@ -61,7 +62,7 @@ export default class Amqp {
     }
   }
 
-  public async connect(): Promise<Connection> {
+  public async connect(): Promise<ChannelModel> {
     const { broker } = this.config
 
     // wtf happened to the types?
@@ -364,15 +365,16 @@ export default class Amqp {
 
   private async assertQueue(configParams?: AmqpConfig): Promise<string> {
     const { queue } = configParams || this.config
-    const { name, exclusive, durable, autoDelete, queueType } = queue
+    const { name, exclusive, durable, autoDelete, queueType, queueArguments } = queue
 
     this.q = await this.channel.assertQueue(name, {
       exclusive,
       durable,
       autoDelete,
       arguments: {
-        "x-queue-type": queueType
-      }
+        "x-queue-type": queueType,
+        ...queueArguments,
+      },
     })
 
     return name

--- a/src/nodes/amqp-in-manual-ack.html
+++ b/src/nodes/amqp-in-manual-ack.html
@@ -17,6 +17,7 @@
       queueExclusive: { value: false },
       queueDurable: { value: false },
       queueAutoDelete: { value: false },
+      queueArguments: { value: '{}' },
       headers: { value: '{}' },
     },
     inputs: 1,
@@ -33,6 +34,11 @@
     },
     oneditprepare: function () {
       $('#node-input-headers').typedInput({
+        type: 'json',
+        types: ['json'],
+      })
+
+      $('#node-input-queueArguments').typedInput({
         type: 'json',
         types: ['json'],
       })
@@ -153,6 +159,10 @@
     <label>&nbsp;</label>
     <input style="width:20px; vertical-align:baseline; margin-right:5px;" type="checkbox" id="node-input-queueAutoDelete">
     <label style="width:auto; margin-top:7px;" for="node-input-queueAutoDelete">Auto Delete</label>
+  </div>
+  <div class="form-row wide-label-amqp-in-manual-ack">
+    <label for="node-input-queueArguments"><i class="fa fa-tag"></i>&nbsp;&nbsp;Queue Arguments</label>
+    <input type="text" id="node-input-queueArguments">
   </div>
 </script>
 

--- a/src/nodes/amqp-in.html
+++ b/src/nodes/amqp-in.html
@@ -17,6 +17,7 @@
       queueExclusive: { value: true },
       queueDurable: { value: false },
       queueAutoDelete: { value: true },
+      queueArguments: { value: '{}' },
       headers: { value: '{}' },
     },
     inputs: 1,
@@ -33,6 +34,11 @@
     },
     oneditprepare: function () {
       $('#node-input-headers').typedInput({
+        type: 'json',
+        types: ['json'],
+      })
+
+      $('#node-input-queueArguments').typedInput({
         type: 'json',
         types: ['json'],
       })
@@ -162,6 +168,10 @@
     <label>&nbsp;</label>
     <input style="width:20px; vertical-align:baseline; margin-right:5px;" type="checkbox" id="node-input-queueAutoDelete">
     <label style="width:auto; margin-top:7px;" for="node-input-queueAutoDelete">Auto Delete</label>
+  </div>
+  <div class="form-row wide-label-amqp-in">
+    <label for="node-input-queueArguments"><i class="fa fa-tag"></i>&nbsp;&nbsp;Queue Arguments</label>
+    <input type="text" id="node-input-queueArguments">
   </div>
 </script>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface AmqpConfig {
     durable: boolean
     autoDelete: boolean
     queueType: string
+    queueArguments?: GenericJsonObject
   }
   amqpProperties: MessageProperties
   headers: GenericJsonObject
@@ -53,6 +54,7 @@ export interface AmqpInNodeDefaults {
   queueExclusive?: any
   queueDurable?: any
   queueAutoDelete?: any
+  queueArguments?: any
   headers?: any
 }
 
@@ -66,6 +68,7 @@ export interface AmqpOutNodeDefaults {
   amqpProperties?: any
   outputs?: any
   rpcTimeoutMilliseconds?: any
+  queueArguments?: any
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -288,7 +288,7 @@ describe('Amqp Class', () => {
 
   it('assertQueue()', async () => {
     const queue = 'queueName'
-    const { queueName, queueExclusive, queueDurable, queueAutoDelete, queueType } =
+    const { queueName, queueExclusive, queueDurable, queueAutoDelete, queueType, queueArguments } =
       nodeConfigFixture
     const assertQueueStub = sinon.stub().resolves({ queue })
     amqp.channel = { assertQueue: assertQueueStub }
@@ -300,7 +300,7 @@ describe('Amqp Class', () => {
         exclusive: queueExclusive,
         durable: queueDurable,
         autoDelete: queueAutoDelete,
-        arguments: { "x-queue-type": queueType },
+        arguments: { "x-queue-type": queueType, ...queueArguments },
       }),
     ).to.equal(true)
   })

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -305,6 +305,28 @@ describe('Amqp Class', () => {
     ).to.equal(true)
   })
 
+  it('assertQueue() without queueArguments', async () => {
+    const queue = 'queueName'
+    const { queueName, queueExclusive, queueDurable, queueAutoDelete, queueType } =
+      nodeConfigFixture
+    const assertQueueStub = sinon.stub().resolves({ queue })
+    amqp.channel = { assertQueue: assertQueueStub }
+
+    await amqp.assertQueue({
+      ...amqp.config,
+      queue: { ...amqp.config.queue, queueArguments: undefined },
+    } as any)
+    expect(assertQueueStub.calledOnce).to.equal(true)
+    expect(
+      assertQueueStub.calledWith(queueName, {
+        exclusive: queueExclusive,
+        durable: queueDurable,
+        autoDelete: queueAutoDelete,
+        arguments: { "x-queue-type": queueType },
+      }),
+    ).to.equal(true)
+  })
+
   it('bindQueue() topic exchange', () => {
     const queue = 'queueName'
     const bindQueueStub = sinon.stub()

--- a/test/doubles.ts
+++ b/test/doubles.ts
@@ -98,6 +98,7 @@ export const nodeConfigFixture: AmqpInNodeDefaults & AmqpOutNodeDefaults = {
   queueExclusive: true,
   queueDurable: false,
   queueAutoDelete: true,
+  queueArguments: { 'x-dead-letter-exchange': 'dlx-exchange' },
 }
 
 export const nodeFixture = {


### PR DESCRIPTION
## Summary
- add queueArguments field to nodes and types
- parse queue arguments and send to `assertQueue`
- test queue arguments handling

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68775d2ad900832ab38660d21be00d01