### PR TITLE
Fix AMQP node listener leak

### DIFF
--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -10,9 +10,6 @@ module.exports = function (RED: NodeRedApp): void {
     let connection = null;
     let channel = null;
 
-    RED.events.once('flows:stopped', () => {
-      clearTimeout(reconnectTimeout)
-    })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -63,6 +60,7 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('input', inputListener)
     // When the server goes down
     this.on('close', async (done: () => void): Promise<void> => {
+      clearTimeout(reconnectTimeout)
       await amqp.close()
       done && done()
     })

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -10,9 +10,6 @@ module.exports = function (RED: NodeRedApp): void {
     let connection = null;
     let channel = null;
 
-    RED.events.once('flows:stopped', () => {
-      clearTimeout(reconnectTimeout)
-    })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -38,6 +35,7 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('input', inputListener)
     // When the node is re-deployed
     this.on('close', async (done: () => void): Promise<void> => {
+      clearTimeout(reconnectTimeout)
       await amqp.close()
       done && done()
     })

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -18,9 +18,6 @@ module.exports = function (RED: NodeRedApp): void {
     let channel = null;
 	let me = this;
 
-    RED.events.once('flows:stopped', () => {
-      clearTimeout(reconnectTimeout)
-    })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -117,6 +114,7 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('input', inputListener)
     // When the node is re-deployed
     this.on('close', async (done: () => void): Promise<void> => {
+      clearTimeout(reconnectTimeout)
       await amqp.close()
       done && done()
     })

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -199,4 +199,21 @@ describe('amqp-in-manual-ack Node', () => {
       },
     )
   })
+
+  it('does not register flows:stopped listener', function (done) {
+    sinon.stub(Amqp.prototype, 'connect').resolves(true as any)
+    sinon.stub(Amqp.prototype, 'initialize')
+
+    helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+      function () {
+        expect(helper._events.listenerCount('flows:stopped')).to.equal(0)
+        const node = helper.getNode('n1')
+        node.close()
+        done()
+      },
+    )
+  })
 })

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -67,6 +67,23 @@ describe('amqp-in Node', () => {
     )
   })
 
+  it('does not register flows:stopped listener', function (done) {
+    sinon.stub(Amqp.prototype, 'connect').resolves(true as any)
+    sinon.stub(Amqp.prototype, 'initialize')
+
+    helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+      function () {
+        expect(helper._events.listenerCount('flows:stopped')).to.equal(0)
+        const amqpInNode = helper.getNode('n1')
+        amqpInNode.close()
+        done()
+      },
+    )
+  })
+
   it('should reconnect to the server', function (done) {
     // @ts-ignore
     Amqp.prototype.channel = {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -69,6 +69,23 @@ describe('amqp-out Node', () => {
     )
   })
 
+  it('does not register flows:stopped listener', function (done) {
+    sinon.stub(Amqp.prototype, 'connect').resolves(true as any)
+    sinon.stub(Amqp.prototype, 'initialize')
+
+    helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+      function () {
+        expect(helper._events.listenerCount('flows:stopped')).to.equal(0)
+        const n1 = helper.getNode('n1')
+        n1.close()
+        done()
+      },
+    )
+  })
+
   it('should connect to the server and send some messages with a dynamic routing key from `msg`', function (done) {
     // @ts-ignore
     Amqp.prototype.channel = {


### PR DESCRIPTION
## Summary
- stop registering `flows:stopped` on node creation
- clear reconnection timers in `close` handlers
- add regression tests for listener cleanup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880933a819c832abdaccfb5de3f62a6