### PR TITLE
fix: properly ack incoming messages and add logging

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -578,7 +578,7 @@ export default class Amqp {
   }
 
   private assembleMessage(amqpMessage: ConsumeMessage): AssembledMessage {
-    const payload = this.parseJson(amqpMessage.content.toString())
+    const payload = this.parseJson(amqpMessage.content.toString(), true)
     ;(amqpMessage as AssembledMessage).payload = payload
     return amqpMessage as AssembledMessage
   }
@@ -587,12 +587,16 @@ export default class Amqp {
     return this.node.type === NodeType.AmqpInManualAck
   }
 
-  private parseJson(jsonInput: unknown): GenericJsonObject {
+  private parseJson(jsonInput: unknown, logError = false): GenericJsonObject {
     let output: unknown
     try {
       output = JSON.parse(jsonInput as string)
-    } catch {
+    } catch (e) {
       output = jsonInput
+      /* istanbul ignore next */
+      if (logError) {
+        this.node.error(`Invalid JSON payload: ${e}`)
+      }
     }
     return output
   }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -148,6 +148,9 @@ export default class Amqp {
         this.q.queue,
         amqpMessage => {
           const msg = this.assembleMessage(amqpMessage)
+          this.node.log(
+            `Received message with deliveryTag: ${msg?.fields?.deliveryTag}`,
+          )
           this.node.send(msg)
           /* istanbul ignore else */
           if (!noAck && !this.isManualAck()) {
@@ -195,6 +198,7 @@ export default class Amqp {
   public ack(msg: AssembledMessage): void {
     const allUpTo = !!msg.manualAck?.allUpTo
     try {
+      this.node.log(`Acking message with deliveryTag: ${msg?.fields?.deliveryTag}`)
       this.channel.ack(msg, allUpTo)
     } catch (e) {
       this.node.error(`Could not ack message: ${e}`)
@@ -203,6 +207,7 @@ export default class Amqp {
 
   public ackAll(): void {
     try {
+      this.node.log('Acking all outstanding messages')
       this.channel.ackAll()
     } catch (e) {
       this.node.error(`Could not ackAll messages: ${e}`)
@@ -213,6 +218,9 @@ export default class Amqp {
     const allUpTo = !!msg.manualAck?.allUpTo
     const requeue = msg.manualAck?.requeue ?? true
     try {
+      this.node.log(
+        `Nacking message with deliveryTag: ${msg?.fields?.deliveryTag}`,
+      )
       this.channel.nack(msg, allUpTo, requeue)
     } catch (e) {
       this.node.error(`Could not nack message: ${e}`)
@@ -222,6 +230,7 @@ export default class Amqp {
   public nackAll(msg: AssembledMessage): void {
     const requeue = msg.manualAck?.requeue ?? true
     try {
+      this.node.log('Nacking all outstanding messages')
       this.channel.nackAll(requeue)
     } catch (e) {
       this.node.error(`Could not nackAll messages: ${e}`)
@@ -231,6 +240,9 @@ export default class Amqp {
   public reject(msg: AssembledMessage): void {
     const requeue = msg.manualAck?.requeue ?? true
     try {
+      this.node.log(
+        `Rejecting message with deliveryTag: ${msg?.fields?.deliveryTag}`,
+      )
       this.channel.reject(msg, requeue)
     } catch (e) {
       this.node.error(`Could not reject message: ${e}`)
@@ -567,11 +579,8 @@ export default class Amqp {
 
   private assembleMessage(amqpMessage: ConsumeMessage): AssembledMessage {
     const payload = this.parseJson(amqpMessage.content.toString())
-
-    return {
-      ...amqpMessage,
-      payload,
-    }
+    ;(amqpMessage as AssembledMessage).payload = payload
+    return amqpMessage as AssembledMessage
   }
 
   private isManualAck(): boolean {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -256,7 +256,9 @@ describe('Amqp Class', () => {
     const messageContent = 'messageContent'
     const send = sinon.stub()
     const error = sinon.stub()
-    const node = { send, error }
+    const log = sinon.stub()
+    const ack = sinon.stub()
+    const node = { send, error, log }
     const channel = {
       consume: function (
         queue: string,
@@ -264,26 +266,48 @@ describe('Amqp Class', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         config: GenericJsonObject,
       ): void {
-        const amqpMessage = { content: messageContent }
+        const amqpMessage = { content: messageContent, fields: { deliveryTag: 1 } }
         cb(amqpMessage)
       },
+      ack,
     }
-    amqp.channel = channel
+    amqp.channel = channel as any
     amqp.assertQueue = assertQueueStub
     amqp.bindQueue = bindQueueStub
-    amqp.q = { queue: 'queueName' }
-    amqp.node = node
+    amqp.q = { queue: 'queueName' } as any
+    amqp.node = node as any
 
     await amqp.consume()
     expect(assertQueueStub.calledOnce).to.equal(true)
     expect(bindQueueStub.calledOnce).to.equal(true)
     expect(send.calledOnce).to.equal(true)
+    expect(log.calledWithMatch('Received message')).to.equal(true)
+    expect(ack.calledOnce).to.equal(true)
     expect(
       send.calledWith({
         content: messageContent,
+        fields: { deliveryTag: 1 },
         payload: messageContent,
       }),
     ).to.equal(true)
+  })
+
+  it('assembleMessage retains reference and parses payload', () => {
+    const amqpMessage: any = { content: Buffer.from('{"a":1}'), fields: { deliveryTag: 1 }, properties: {} }
+    const result = (amqp as any).assembleMessage(amqpMessage)
+    expect(result).to.equal(amqpMessage)
+    expect(result).to.have.property('payload').that.deep.equals({ a: 1 })
+  })
+
+  it('ack() logs and delegates to channel', () => {
+    const logStub = sinon.stub()
+    const ackStub = sinon.stub()
+    amqp.node = { ...nodeFixture, log: logStub, error: sinon.stub() }
+    amqp.channel = { ack: ackStub } as any
+    const msg: any = { fields: { deliveryTag: 5 } }
+    amqp.ack(msg)
+    expect(ackStub.calledOnceWith(msg, false)).to.be.true
+    expect(logStub.calledWithMatch('Acking message')).to.be.true
   })
 
   describe('publish()', () => {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -299,6 +299,20 @@ describe('Amqp Class', () => {
     expect(result).to.have.property('payload').that.deep.equals({ a: 1 })
   })
 
+  it('assembleMessage logs error when payload is invalid JSON', () => {
+    const amqpMessage: any = {
+      content: Buffer.from('{invalid'),
+      fields: { deliveryTag: 1 },
+      properties: {},
+    }
+    const errorStub = sinon.stub()
+    amqp.node = { ...nodeFixture, error: errorStub }
+    const result = (amqp as any).assembleMessage(amqpMessage)
+    expect(result).to.equal(amqpMessage)
+    expect(result).to.have.property('payload', '{invalid')
+    expect(errorStub.calledWithMatch('Invalid JSON payload')).to.be.true
+  })
+
   it('ack() logs and delegates to channel', () => {
     const logStub = sinon.stub()
     const ackStub = sinon.stub()


### PR DESCRIPTION
## Summary
- ensure acked messages use original AMQP object to avoid unacked deliveries
- add detailed logging for received, acked, nacked, and rejected messages
- add unit tests for message assembly and ack logging

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aea75eb924832aa1d89ad1f68b3ad1