### PR TITLE
fix: output compiled nodes to js

### DIFF
--- a/test/build-output.spec.ts
+++ b/test/build-output.spec.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export {}
+const { expect } = require('chai')
+const fs = require('fs')
+const path = require('path')
+
+describe('build output', () => {
+  const base = path.join(__dirname, '..', 'build')
+  const nodeDir = path.join(base, 'src', 'nodes')
+  const nodes = ['amqp-in', 'amqp-out', 'amqp-broker', 'amqp-in-manual-ack']
+
+  it('does not create top-level build/nodes directory', () => {
+    expect(fs.existsSync(path.join(base, 'nodes'))).to.be.false
+  })
+
+  nodes.forEach(name => {
+    it(`should generate ${name}.js`, () => {
+      expect(fs.existsSync(path.join(nodeDir, `${name}.js`))).to.be.true
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "removeComments": false,
     "target": "es2017",
     "sourceMap": true,
-    "outDir": "build",
+    "outDir": "build/src",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- compile TypeScript into `build/src` so Node-RED nodes produce `.js` files
- add tests asserting compiled node scripts exist under `build/src/nodes`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aeb17eb05c832a9d7844a783afece1