### PR TITLE
fix: prevent false connected state when consume setup fails

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -192,6 +192,7 @@ export default class Amqp {
       )
     } catch (e) {
       this.node.error(`Could not consume message: ${e}`)
+      throw e
     }
   }
 
@@ -303,6 +304,8 @@ export default class Amqp {
       outputs: rpcRequested,
     } = config
 
+    let cancelRpcConsumer: (() => Promise<void>) | null = null
+
     try {
       let correlationId = ''
       let replyTo = ''
@@ -315,7 +318,10 @@ export default class Amqp {
           uuidv4()
         replyTo =
           properties?.replyTo || this.config.amqpProperties?.replyTo || uuidv4()
-        await this.handleRemoteProcedureCall(correlationId, replyTo)
+        cancelRpcConsumer = await this.handleRemoteProcedureCall(
+          correlationId,
+          replyTo,
+        )
       }
 
       const options = {
@@ -337,6 +343,9 @@ export default class Amqp {
         await (this.channel as ConfirmChannel).waitForConfirms()
       }
     } catch (e) {
+      if (cancelRpcConsumer) {
+        await cancelRpcConsumer()
+      }
       this.node.error(`Could not publish message: ${e}`)
       throw e
     }
@@ -357,36 +366,87 @@ export default class Amqp {
   private async handleRemoteProcedureCall(
     correlationId: string,
     replyTo: string,
-  ): Promise<void> {
+  ): Promise<() => Promise<void>> {
     const rpcConfig = this.getRpcConfig(replyTo)
+    let queueName = ''
 
     try {
       // If we try to delete a queue that's already deleted
       // bad things will happen.
       let rpcQueueHasBeenDeleted = false
+      let rpcResponseFinalized = false
       let additionalErrorMessaging = ''
       let rpcTimeout: NodeJS.Timeout | null = null
+      let rpcConsumerTag = ''
+      let cleanupPromise: Promise<void> | null = null
+
+      const clearRpcTimeout = (): void => {
+        if (rpcTimeout) {
+          clearTimeout(rpcTimeout)
+          this.rpcTimeouts.delete(rpcTimeout)
+          rpcTimeout = null
+        }
+      }
+
+      const finalizeRpcResponse = (): boolean => {
+        if (rpcResponseFinalized) {
+          return false
+        }
+        rpcResponseFinalized = true
+        clearRpcTimeout()
+        return true
+      }
+
+      const cleanupRpcResources = async (): Promise<void> => {
+        if (rpcQueueHasBeenDeleted || !queueName) {
+          return
+        }
+
+        if (!cleanupPromise) {
+          cleanupPromise = (async () => {
+            try {
+              await this.channel.deleteQueue(queueName)
+              rpcQueueHasBeenDeleted = true
+            } catch (deleteError) {
+              this.node.error(`Error trying to cancel RPC consumer: ${deleteError}`)
+
+              const canCancelConsumer = typeof this.channel.cancel === 'function'
+              if (canCancelConsumer && rpcConsumerTag) {
+                try {
+                  await this.channel.cancel(rpcConsumerTag)
+                  rpcQueueHasBeenDeleted = true
+                } catch (cancelError) {
+                  this.node.error(`Error trying to cancel RPC consumer: ${cancelError}`)
+                }
+              }
+            } finally {
+              cleanupPromise = null
+            }
+          })()
+        }
+
+        await cleanupPromise
+      }
+
+      const cancelRpcConsumer = async (): Promise<void> => {
+        finalizeRpcResponse()
+        await cleanupRpcResources()
+      }
 
       /************************************
        * assert queue and set up consumer
        ************************************/
-      const queueName = await this.assertQueue(rpcConfig)
+      queueName = await this.assertQueue(rpcConfig)
 
-      await this.channel.consume(
+      const consumeResponse = await this.channel.consume(
         queueName,
-        async amqpMessage => {
+        amqpMessage => {
           if (amqpMessage) {
             const msg = this.assembleMessage(amqpMessage)
             if (msg.properties.correlationId === correlationId) {
-              this.node.send(msg as any)
-              /* istanbul ignore else */
-              if (!rpcQueueHasBeenDeleted) {
-                await this.channel.deleteQueue(queueName)
-                rpcQueueHasBeenDeleted = true
-                if (rpcTimeout) {
-                  clearTimeout(rpcTimeout)
-                  this.rpcTimeouts.delete(rpcTimeout)
-                }
+              if (finalizeRpcResponse()) {
+                this.node.send(msg as any)
+                void cleanupRpcResources()
               }
             } else {
               additionalErrorMessaging += ` Correlation ids do not match. Expecting: ${correlationId}, received: ${msg.properties.correlationId}`
@@ -395,28 +455,27 @@ export default class Amqp {
         },
         { noAck: rpcConfig.noAck },
       )
+      rpcConsumerTag = consumeResponse?.consumerTag || ''
 
       /****************************************
        * Check if RPC has timed out and handle
        ****************************************/
       rpcTimeout = setTimeout(async () => {
-        if (rpcTimeout) {
-          this.rpcTimeouts.delete(rpcTimeout)
-        }
+        clearRpcTimeout()
         if (this.closed) {
           return
         }
 
         try {
-          if (!rpcQueueHasBeenDeleted) {
+          if (finalizeRpcResponse()) {
             this.node.send({
               payload: {
                 message: `Timeout while waiting for RPC response.${additionalErrorMessaging}`,
                 config: rpcConfig,
               },
             })
-            await this.channel.deleteQueue(queueName)
           }
+          await cleanupRpcResources()
         } catch (e) {
           // TODO: Keep an eye on this
           // This might close the whole channel
@@ -424,8 +483,16 @@ export default class Amqp {
         }
       }, rpcConfig.rpcTimeout || 3000)
       this.rpcTimeouts.add(rpcTimeout)
+      return cancelRpcConsumer
     } catch (e) {
+      // If setup failed after queue assertion, try to clean up the temporary RPC queue.
+      if (queueName) {
+        await this.channel.deleteQueue(queueName).catch(deleteError => {
+          this.node.error(`Error trying to cancel RPC consumer: ${deleteError}`)
+        })
+      }
       this.node.error(`Could not consume RPC message: ${e}`)
+      throw e
     }
   }
 

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -110,10 +110,18 @@ module.exports = function (RED: NodeRedApp): void {
     })
 
     const removeEventListeners = (): void => {
-      connection?.off?.('close', onConnClose)
-      connection?.off?.('error', onConnError)
-      channel?.off?.('close', onChannelClose)
-      channel?.off?.('error', onChannelError)
+      if (typeof onConnClose === 'function') {
+        connection?.off?.('close', onConnClose)
+      }
+      if (typeof onConnError === 'function') {
+        connection?.off?.('error', onConnError)
+      }
+      if (typeof onChannelClose === 'function') {
+        channel?.off?.('close', onChannelClose)
+      }
+      if (typeof onChannelError === 'function') {
+        channel?.off?.('error', onChannelError)
+      }
     }
 
     async function initializeNode(nodeIns: Node) {
@@ -126,29 +134,33 @@ module.exports = function (RED: NodeRedApp): void {
         }
         reconnectScheduled = true
 
-        nodeIns.log('Reconnect requested: closing AMQP resources')
-        removeEventListeners()
-        await amqp.close()
-        channel = null
-        connection = null
-
-        // always clear timer before set it;
         clearTimeout(reconnectTimeout)
-        nodeIns.log('Reconnect scheduled in 2000ms')
-        reconnectTimeout = setTimeout(() => {
-          reconnectScheduled = false
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect timer fired but node is shutting down')
-            return
-          }
-          nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-          void initializeNode(nodeIns).catch(() => {
-            if (typeof reconnect === 'function') {
-              nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-              void reconnect()
+        try {
+          nodeIns.log('Reconnect requested: closing AMQP resources')
+          removeEventListeners()
+          await amqp.close()
+          channel = null
+          connection = null
+
+          nodeIns.log('Reconnect scheduled in 2000ms')
+          reconnectTimeout = setTimeout(() => {
+            reconnectScheduled = false
+            if (isShuttingDown) {
+              nodeIns.log('Reconnect timer fired but node is shutting down')
+              return
             }
-          })
-        }, 2000)
+            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
+            void initializeNode(nodeIns).catch(() => {
+              if (typeof reconnect === 'function') {
+                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
+                void reconnect()
+              }
+            })
+          }, 2000)
+        } catch (error) {
+          reconnectScheduled = false
+          throw error
+        }
       }
 
 
@@ -162,21 +174,49 @@ module.exports = function (RED: NodeRedApp): void {
 
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
-            await reconnect()
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+              })
+            }
           }
 
           onConnError = async e => {
-            reconnectOnError && (await reconnect())
+            if (reconnectOnError) {
+              try {
+                await reconnect()
+              } catch (reconnectError) {
+                nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
+                  payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+                })
+              }
+            }
             nodeIns.error(`Connection error ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectionErrorEvent } })
           }
 
           onChannelClose = async () => {
             nodeIns.warn('AMQP channel closed event received')
-            await reconnect()
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+              })
+            }
           }
 
           onChannelError = async e => {
-            reconnectOnError && (await reconnect())
+            if (reconnectOnError) {
+              try {
+                await reconnect()
+              } catch (reconnectError) {
+                nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
+                  payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+                })
+              }
+            }
             nodeIns.error(`Channel error ${e}`, { payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent } })
           }
 

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -70,10 +70,18 @@ module.exports = function (RED: NodeRedApp): void {
     
 
     const removeEventListeners = (): void => {
-      connection?.off?.('close', onConnClose)
-      connection?.off?.('error', onConnError)
-      channel?.off?.('close', onChannelClose)
-      channel?.off?.('error', onChannelError)
+      if (typeof onConnClose === 'function') {
+        connection?.off?.('close', onConnClose)
+      }
+      if (typeof onConnError === 'function') {
+        connection?.off?.('error', onConnError)
+      }
+      if (typeof onChannelClose === 'function') {
+        channel?.off?.('close', onChannelClose)
+      }
+      if (typeof onChannelError === 'function') {
+        channel?.off?.('error', onChannelError)
+      }
     }
 
     async function initializeNode(nodeIns: Node) {
@@ -85,29 +93,33 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         reconnectScheduled = true
-        nodeIns.log('Reconnect requested: closing AMQP resources')
-        removeEventListeners()
-        await amqp.close()
-        channel = null
-        connection = null
-
-        // always clear timer before set it;
         clearTimeout(reconnectTimeout)
-        nodeIns.log('Reconnect scheduled in 2000ms')
-        reconnectTimeout = setTimeout(() => {
-          reconnectScheduled = false
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect timer fired but node is shutting down')
-            return
-          }
-          nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-          void initializeNode(nodeIns).catch(() => {
-            if (typeof reconnect === 'function') {
-              nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-              void reconnect()
+        try {
+          nodeIns.log('Reconnect requested: closing AMQP resources')
+          removeEventListeners()
+          await amqp.close()
+          channel = null
+          connection = null
+
+          nodeIns.log('Reconnect scheduled in 2000ms')
+          reconnectTimeout = setTimeout(() => {
+            reconnectScheduled = false
+            if (isShuttingDown) {
+              nodeIns.log('Reconnect timer fired but node is shutting down')
+              return
             }
-          })
-        }, 2000)
+            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
+            void initializeNode(nodeIns).catch(() => {
+              if (typeof reconnect === 'function') {
+                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
+                void reconnect()
+              }
+            })
+          }, 2000)
+        } catch (error) {
+          reconnectScheduled = false
+          throw error
+        }
       }
 
       try {
@@ -120,11 +132,25 @@ module.exports = function (RED: NodeRedApp): void {
 
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
-            await reconnect()
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+              })
+            }
           }
 
           onConnError = async e => {
-            reconnectOnError && (await reconnect())
+            if (reconnectOnError) {
+              try {
+                await reconnect()
+              } catch (reconnectError) {
+                nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
+                  payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+                })
+              }
+            }
             nodeIns.error(`Connection error ${e}`, {
               payload: { error: e, location: ErrorLocationEnum.ConnectionErrorEvent },
             })
@@ -132,11 +158,25 @@ module.exports = function (RED: NodeRedApp): void {
 
           onChannelClose = async () => {
             nodeIns.warn('AMQP channel closed event received')
-            await reconnect()
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+              })
+            }
           }
 
           onChannelError = async e => {
-            reconnectOnError && (await reconnect())
+            if (reconnectOnError) {
+              try {
+                await reconnect()
+              } catch (reconnectError) {
+                nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
+                  payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+                })
+              }
+            }
             nodeIns.error(`Channel error ${e}`, {
               payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent },
             })

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -43,20 +43,42 @@ module.exports = function (RED: NodeRedApp): void {
     const reconnectOnError = configAmqp.reconnectOnError
 
     const removeEventListeners = (): void => {
-      connection?.off?.('close', onConnClose)
-      connection?.off?.('error', onConnError)
-      channel?.off?.('close', onChannelClose)
-      channel?.off?.('error', onChannelError)
+      if (typeof onConnClose === 'function') {
+        connection?.off?.('close', onConnClose)
+      }
+      if (typeof onConnError === 'function') {
+        connection?.off?.('error', onConnError)
+      }
+      if (typeof onChannelClose === 'function') {
+        channel?.off?.('close', onChannelClose)
+      }
+      if (typeof onChannelError === 'function') {
+        channel?.off?.('error', onChannelError)
+      }
     }
 
     const setupEventListeners = (nodeIns: Node): void => {
       onConnClose = async () => {
         nodeIns.warn('AMQP connection closed event received')
-        await reconnect()
+        try {
+          await reconnect()
+        } catch (reconnectError) {
+          nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
+            payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+          })
+        }
       }
 
       onConnError = async e => {
-        reconnectOnError && (await reconnect())
+        if (reconnectOnError) {
+          try {
+            await reconnect()
+          } catch (reconnectError) {
+            nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
+              payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
+            })
+          }
+        }
         nodeIns.error(`Connection error ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectionErrorEvent },
         })
@@ -64,11 +86,25 @@ module.exports = function (RED: NodeRedApp): void {
 
       onChannelClose = async () => {
         nodeIns.warn('AMQP channel closed event received')
-        await reconnect()
+        try {
+          await reconnect()
+        } catch (reconnectError) {
+          nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
+            payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+          })
+        }
       }
 
       onChannelError = async e => {
-        reconnectOnError && (await reconnect())
+        if (reconnectOnError) {
+          try {
+            await reconnect()
+          } catch (reconnectError) {
+            nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
+              payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+            })
+          }
+        }
         nodeIns.error(`Channel error ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent },
         })
@@ -153,8 +189,8 @@ module.exports = function (RED: NodeRedApp): void {
           }
           break
         case 'jsonata': {
-          const expr = RED.util.prepareJSONataExpression(exchangeRoutingKey, this)
           try {
+            const expr = RED.util.prepareJSONataExpression(exchangeRoutingKey, this)
             const result = await new Promise<unknown>((resolve, reject) => {
               RED.util.evaluateJSONataExpression(expr, msg, (err, value) => {
                 if (err) {
@@ -240,28 +276,33 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         reconnectScheduled = true
-        nodeIns.log('Reconnect requested: closing AMQP resources')
-        removeEventListeners()
-        await amqp.close()
-        channel = null
-        connection = null
-
         clearTimeout(reconnectTimeout)
-        nodeIns.log('Reconnect scheduled in 2000ms')
-        reconnectTimeout = setTimeout(() => {
-          reconnectScheduled = false
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect timer fired but node is shutting down')
-            return
-          }
-          nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-          void initializeNode(nodeIns).catch(() => {
-            if (typeof reconnect === 'function') {
-              nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-              void reconnect()
+        try {
+          nodeIns.log('Reconnect requested: closing AMQP resources')
+          removeEventListeners()
+          await amqp.close()
+          channel = null
+          connection = null
+
+          nodeIns.log('Reconnect scheduled in 2000ms')
+          reconnectTimeout = setTimeout(() => {
+            reconnectScheduled = false
+            if (isShuttingDown) {
+              nodeIns.log('Reconnect timer fired but node is shutting down')
+              return
             }
-          })
-        }, 2000)
+            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
+            void initializeNode(nodeIns).catch(() => {
+              if (typeof reconnect === 'function') {
+                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
+                void reconnect()
+              }
+            })
+          }, 2000)
+        } catch (error) {
+          reconnectScheduled = false
+          throw error
+        }
       }
 
       try {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -1059,7 +1059,12 @@ describe('Amqp Class', () => {
     amqp.node = { send: sinon.stub(), error: errorStub }
     amqp.q = { queue: 'queueName' }
 
-    await amqp.consume()
+    try {
+      await amqp.consume()
+      expect.fail('consume should throw')
+    } catch (e: any) {
+      expect(String(e.message)).to.match(/bind fail/)
+    }
     expect(consumeStub.called).to.equal(false)
     expect(errorStub.calledOnce).to.equal(true)
   })
@@ -1235,6 +1240,86 @@ describe('Amqp Class', () => {
         expect(errorStub.calledWithMatch('Error trying to cancel RPC consumer')).to.be.true;
     });
 
+    it('handles error when deleting queue after receiving RPC reply', async () => {
+        const sendStub = sinon.stub();
+        const deleteQueueStub = sinon.stub().rejects(new Error('delete failed'));
+        const cancelStub = sinon.stub().resolves();
+        const assertQueueStub = sinon.stub().resolves('rpc-queue');
+        const errorStub = sinon.stub();
+        let consumeCallback;
+        const consumeStub = sinon.stub().callsFake((queue, cb) => {
+            consumeCallback = cb;
+            return Promise.resolve({ consumerTag: 'rpc-consumer-tag' });
+        });
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: errorStub };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            cancel: cancelStub,
+            publish: sinon.stub(),
+        };
+
+        amqp.config.outputs = 1;
+
+        await amqp.publish('a message', {
+            correlationId: 'test-correlation-id',
+            replyTo: 'rpc-queue',
+        });
+
+        await consumeCallback({
+            properties: { correlationId: 'test-correlation-id' },
+            content: Buffer.from('{"response": true}'),
+        });
+        await Promise.resolve();
+
+        expect(sendStub.calledOnce).to.be.true;
+        expect(deleteQueueStub.calledOnce).to.be.true;
+        expect(cancelStub.calledOnceWith('rpc-consumer-tag')).to.be.true;
+        expect(errorStub.calledWithMatch('Error trying to cancel RPC consumer')).to.be.true;
+    });
+
+    it('emits only one output when RPC times out and a late reply arrives during cleanup', async () => {
+        const sendStub = sinon.stub();
+        const assertQueueStub = sinon.stub().resolves('rpc-queue');
+        let consumeCallback;
+        let resolveDelete;
+        const deleteQueueStub = sinon.stub().callsFake(() =>
+            new Promise(resolve => {
+                resolveDelete = resolve;
+            })
+        );
+        const consumeStub = sinon.stub().callsFake((queue, cb) => {
+            consumeCallback = cb;
+            return Promise.resolve();
+        });
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub() };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            publish: sinon.stub(),
+        };
+
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+
+        await amqp.publish('a message', { correlationId: 'test-correlation-id' });
+        await clock.tickAsync(1001);
+
+        consumeCallback({
+            properties: { correlationId: 'test-correlation-id' },
+            content: Buffer.from('{"response": true}'),
+        });
+        resolveDelete();
+        await Promise.resolve();
+
+        expect(sendStub.calledOnce).to.be.true;
+        expect(sendStub.firstCall.args[0].payload.message).to.match(/Timeout while waiting for RPC response/);
+    });
+
     it('clears RPC timeout when closed before timeout elapses', async () => {
         const sendStub = sinon.stub();
         const deleteQueueStub = sinon.stub().resolves();
@@ -1273,18 +1358,96 @@ describe('Amqp Class', () => {
     it('handles error during RPC setup', async () => {
         const errorStub = sinon.stub();
         const assertQueueStub = sinon.stub().rejects(new Error('assert failed'));
+        const publishStub = sinon.stub();
 
         amqp.node = { ...nodeFixture, error: errorStub };
         amqp.channel = {
             assertQueue: assertQueueStub,
-            publish: sinon.stub(),
+            publish: publishStub,
         };
 
         amqp.config.outputs = 1; // Enable RPC
 
-        await amqp.publish('a message');
+        try {
+            await amqp.publish('a message');
+            expect.fail('publish should throw');
+        } catch (e) {
+            expect(e.message).to.equal('assert failed');
+        }
 
         expect(assertQueueStub.calledOnce).to.be.true;
+        expect(publishStub.called).to.be.false;
+        expect(errorStub.calledWithMatch('Could not consume RPC message')).to.be.true;
+        expect(errorStub.calledWithMatch('Could not publish message')).to.be.true;
+    });
+
+    it('does not emit an RPC timeout when publish fails after RPC setup', async () => {
+        const sendStub = sinon.stub();
+        const errorStub = sinon.stub();
+        const assertQueueStub = sinon.stub().resolves('rpc-queue');
+        const consumeStub = sinon.stub().resolves({ consumerTag: 'rpc-consumer-tag' });
+        const deleteQueueStub = sinon.stub().resolves();
+        const publishStub = sinon.stub().throws(new Error('publish failed'));
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: errorStub };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            publish: publishStub,
+        };
+
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+
+        try {
+            await amqp.publish('a message', {
+                correlationId: 'test-correlation-id',
+                replyTo: 'rpc-queue',
+            });
+            expect.fail('publish should throw');
+        } catch (e) {
+            expect(e.message).to.equal('publish failed');
+        }
+
+        await clock.tickAsync(1001);
+
+        expect(sendStub.called).to.be.false;
+        expect(deleteQueueStub.calledOnceWith('rpc-queue')).to.be.true;
+        expect(errorStub.calledWithMatch('Could not publish message')).to.be.true;
+    });
+
+    it('cleans up asserted RPC queue when consume setup fails', async () => {
+        const errorStub = sinon.stub();
+        const assertQueueStub = sinon.stub().resolves('rpc-queue');
+        const consumeStub = sinon.stub().rejects(new Error('consume setup failed'));
+        const deleteQueueStub = sinon.stub().resolves();
+        const publishStub = sinon.stub();
+
+        amqp.node = { ...nodeFixture, error: errorStub };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            publish: publishStub,
+        };
+
+        amqp.config.outputs = 1;
+
+        try {
+            await amqp.publish('a message', {
+                correlationId: 'test-correlation-id',
+                replyTo: 'rpc-queue',
+            });
+            expect.fail('publish should throw');
+        } catch (e) {
+            expect(e.message).to.equal('consume setup failed');
+        }
+
+        expect(assertQueueStub.calledOnce).to.be.true;
+        expect(consumeStub.calledOnce).to.be.true;
+        expect(deleteQueueStub.calledOnceWith('rpc-queue')).to.be.true;
+        expect(publishStub.called).to.be.false;
         expect(errorStub.calledWithMatch('Could not consume RPC message')).to.be.true;
     });
 

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -360,6 +360,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -379,6 +380,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -404,6 +406,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     await helper.load(
@@ -426,6 +429,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     await helper.load(
@@ -447,6 +451,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
@@ -484,11 +489,99 @@ describe('amqp-in-manual-ack Node', () => {
     expect(doneError?.message).to.match(/reconnect failed/i)
   })
 
+  it('allows repeated reconnect control attempts after close failure', async function () {
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(closeStub.calledTwice).to.be.true
+  })
+
+  it('does not emit unhandled rejection when reconnect fails in connection close handler', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    const callErrors: unknown[] = []
+    n1.on('call:error', call => {
+      callErrors.push(call.args[0])
+    })
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      onConnClose()
+      await new Promise(resolve => setTimeout(resolve, 50))
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+
+    expect(unhandledReason).to.equal(undefined)
+    expect(
+      callErrors.some(error => /Reconnect failed after connection close/i.test(String(error))),
+    ).to.be.true
+  })
+
+  it('handles reconnect control before listeners are assigned', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(new Promise(() => undefined) as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    const callErrors: unknown[] = []
+    n1.on('call:error', call => {
+      callErrors.push(call.args[0])
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(closeStub.calledOnce).to.be.true
+    expect(callErrors.some(err => String(err).includes('ERR_INVALID_ARG_TYPE'))).to.be.false
+  })
+
   it('does not reconnect after node close when late connection close event arrives', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -510,6 +603,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -561,6 +655,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     await helper.load(
@@ -578,6 +673,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
@@ -614,6 +710,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture));
@@ -630,6 +727,7 @@ describe('amqp-in-manual-ack Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves();
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture));

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -235,6 +235,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub(), consume: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
 
     await helper.load(
@@ -261,6 +262,25 @@ describe('amqp-in Node', () => {
     )
 
     expect(closeStub.called).to.be.true
+  })
+
+  it('does not register listeners or report connected when consume setup fails', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'assertQueue').rejects(new Error('assertQueue failed'))
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+
+    expect(closeStub.called).to.be.true
+    expect(connectionMock.on.called).to.be.false
+    expect(channelMock.on.called).to.be.false
   })
 
   it('should reconnect on input message', done => {
@@ -304,6 +324,93 @@ describe('amqp-in Node', () => {
     expect(doneError?.message).to.match(/reconnect failed/i)
   })
 
+  it('allows repeated reconnect control attempts after close failure', async function () {
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(closeStub.calledTwice).to.be.true
+  })
+
+  it('does not emit unhandled rejection when reconnect fails in connection close handler', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    const callErrors: unknown[] = []
+    n1.on('call:error', call => {
+      callErrors.push(call.args[0])
+    })
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      onConnClose()
+      await new Promise(resolve => setTimeout(resolve, 50))
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+
+    expect(unhandledReason).to.equal(undefined)
+    expect(
+      callErrors.some(error => /Reconnect failed after connection close/i.test(String(error))),
+    ).to.be.true
+  })
+
+  it('handles reconnect control before listeners are assigned', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(new Promise(() => undefined) as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    const callErrors: unknown[] = []
+    n1.on('call:error', call => {
+      callErrors.push(call.args[0])
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    n1.receive({ payload: { reconnectCall: true } })
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(closeStub.calledOnce).to.be.true
+    expect(callErrors.some(err => String(err).includes('ERR_INVALID_ARG_TYPE'))).to.be.false
+  })
+
   it('should handle channel errors', function (done) {
     const flow = [
       { id: 'n1', type: 'amqp-in', name: 'test name', broker: 'b1' },
@@ -333,6 +440,7 @@ describe('amqp-in Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     await helper.load(
@@ -355,6 +463,7 @@ describe('amqp-in Node', () => {
     sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     await helper.load(
@@ -372,6 +481,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -394,6 +504,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load(
@@ -419,6 +530,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     await helper.load(
@@ -436,6 +548,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     const flow = JSON.parse(JSON.stringify(amqpInFlowFixture));
@@ -456,6 +569,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     await helper.load(
@@ -484,6 +598,7 @@ describe('amqp-in Node', () => {
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+    sinon.stub(Amqp.prototype, 'consume').resolves();
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     const flow = JSON.parse(JSON.stringify(amqpInFlowFixture));

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -133,6 +133,36 @@ describe('amqp-out Node', () => {
     expect(publishStub.notCalled).to.be.true;
   });
 
+  it('calls done with error when JSONata expression is malformed', async function () {
+    const publishStub = sinon.stub(Amqp.prototype, 'publish');
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() };
+    const channelMock = { on: sinon.stub(), off: sinon.stub() };
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any);
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any);
+
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture));
+    flowFixture[0].exchangeRoutingKeyType = 'jsonata';
+    flowFixture[0].exchangeRoutingKey = '(';
+
+    await helper.load([amqpOut, amqpBroker], flowFixture, credentialsFixture);
+    const amqpOutNode = helper.getNode('n1');
+    const callErrors: unknown[] = [];
+    amqpOutNode.on('call:error', call => {
+      callErrors.push(call.args[0]);
+    });
+
+    await amqpOutNode.receive({ payload: 'foo' });
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const doneError = callErrors.find(arg => arg instanceof Error) as Error | undefined;
+    const hasLoggedJsonataError = callErrors.some(arg =>
+      /Failed to evaluate JSONata expression/i.test(String(arg)),
+    );
+    expect(doneError).to.not.equal(undefined);
+    expect(hasLoggedJsonataError).to.be.true;
+    expect(publishStub.notCalled).to.be.true;
+  });
+
   it('should handle dynamic routing key from `flow` context', async function () {
     const setRoutingKeyStub = sinon.stub(Amqp.prototype, 'setRoutingKey');
     sinon.stub(Amqp.prototype, 'publish');
@@ -360,6 +390,23 @@ describe('amqp-out Node', () => {
     )
 
     expect(closeStub.called).to.be.true
+  })
+
+  it('closes cleanly before listeners are assigned', async function () {
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(new Promise(() => undefined) as any)
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+
+    const amqpOutNode = helper.getNode('n1')
+    await amqpOutNode.close()
+
+    expect(closeStub.calledOnce).to.be.true
   })
 
   it('should connect to the server and send some messages with a dynamic routing key from `msg`', function (done) {
@@ -676,6 +723,68 @@ describe('amqp-out Node', () => {
         done()
       },
     )
+  })
+
+  it('allows repeated reconnect attempts after close failure', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon
+      .stub(Amqp.prototype, 'connect')
+      .resolves(connectionMock as any)
+    sinon
+      .stub(Amqp.prototype, 'initialize')
+      .resolves(channelMock as any)
+    const closeStub = sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+
+    const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+    await onConnClose().catch(() => undefined)
+    await onConnClose().catch(() => undefined)
+
+    expect(closeStub.calledTwice).to.be.true
+  })
+
+  it('does not emit unhandled rejection when reconnect fails in connection close handler', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('reconnect failed'))
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+
+    const n1 = helper.getNode('n1')
+    const callErrors: unknown[] = []
+    n1.on('call:error', call => {
+      callErrors.push(call.args[0])
+    })
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      onConnClose()
+      await new Promise(resolve => setTimeout(resolve, 50))
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+
+    expect(unhandledReason).to.equal(undefined)
+    expect(
+      callErrors.some(error => /Reconnect failed after connection close/i.test(String(error))),
+    ).to.be.true
   })
 
   it('does not reconnect after node close when late connection close event arrives', async function () {


### PR DESCRIPTION
## Summary
- rethrow consume setup/runtime failures from `Amqp.consume()` so callers can treat consumer startup failures as real initialization failures
- prevent `amqp-out`, `amqp-in`, and `amqp-in-manual-ack` reconnect event handlers from leaking unhandled promise rejections when reconnect fails
- handle malformed JSONata routing-key expressions in `amqp-out` by evaluating preparation inside the guarded error path

## Why
`amqp-in` could report `Connected` even when consumer setup failed because `consume()` logged errors but resolved successfully. This caused an incorrect node status and masked startup failures.

## Tests
- added/updated unit tests for consume error propagation and node behavior when consume setup fails
- added regression tests for malformed JSONata routing-key expressions
- added regression tests confirming reconnect event handlers do not emit `unhandledRejection` on reconnect failure

Validation run:
- `npm run lint`
- `npm test`