### PR TITLE
Fix AMQP reconnect and health state handling

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -784,7 +784,7 @@ export default class Amqp {
 
     if (error !== undefined) {
       this.broker.lastError[this.node.id] = this.toBrokerNodeError(error)
-    } else {
+    } else if (state === 'connected') {
       delete this.broker.lastError[this.node.id]
     }
   }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -132,9 +132,6 @@ export default class Amqp {
       }
     }
 
-    this.setBrokerNodeState('connected')
-    this.node.status(NODE_STATUS.Connected)
-
     entry.count += 1
     this.connection = entry.connection
 
@@ -160,6 +157,11 @@ export default class Amqp {
     return this.connection
   }
 
+  public markConnected(): void {
+    this.setBrokerNodeState('connected')
+    this.node.status(NODE_STATUS.Connected)
+  }
+
   public async initialize(): Promise<Channel> {
     await this.createChannel()
     await this.assertExchange()
@@ -176,6 +178,9 @@ export default class Amqp {
         amqpMessage => {
           if (!amqpMessage) {
             this.node.warn('AMQP consumer was cancelled')
+            this.node.status(NODE_STATUS.Disconnected)
+            const eventEmitterNode = this.node as unknown as { emit?: (event: string) => void }
+            eventEmitterNode.emit?.('amqp:consumer-cancelled')
             return
           }
           const msg = this.assembleMessage(amqpMessage)
@@ -213,6 +218,7 @@ export default class Amqp {
       this.vhostOverride = newVhost
       await this.connect()
       await this.initialize()
+      this.markConnected()
     } catch (e) {
       this.node.error(`Could not switch vhost: ${e}`)
       throw e
@@ -658,6 +664,7 @@ export default class Amqp {
       }
     } catch (e) {
       this.node.error(`Could not bind queue: ${e}`)
+      throw e
     }
   }
 

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -647,24 +647,19 @@ export default class Amqp {
       configParams?.exchange || this.config.exchange
     const { headers } = configParams?.amqpProperties || this.config
 
-    try {
-      if (this.canHaveRoutingKey(type) && name) {
-        const promises = this.parseRoutingKeys(routingKey).map(key =>
-          this.channel.bindQueue(this.q.queue, name, key),
-        )
-        await Promise.all(promises)
-      }
+    if (this.canHaveRoutingKey(type) && name) {
+      const promises = this.parseRoutingKeys(routingKey).map(key =>
+        this.channel.bindQueue(this.q.queue, name, key),
+      )
+      await Promise.all(promises)
+    }
 
-      if (type === ExchangeType.Fanout) {
-        await this.channel.bindQueue(this.q.queue, name, '')
-      }
+    if (type === ExchangeType.Fanout) {
+      await this.channel.bindQueue(this.q.queue, name, '')
+    }
 
-      if (type === ExchangeType.Headers) {
-        await this.channel.bindQueue(this.q.queue, name, '', headers)
-      }
-    } catch (e) {
-      this.node.error(`Could not bind queue: ${e}`)
-      throw e
+    if (type === ExchangeType.Headers) {
+      await this.channel.bindQueue(this.q.queue, name, '', headers)
     }
   }
 

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -162,6 +162,20 @@ export default class Amqp {
     this.node.status(NODE_STATUS.Connected)
   }
 
+  public removeBrokerNodeState(): void {
+    if (!this.broker || !this.node?.id) {
+      return
+    }
+
+    if (this.broker.nodeStates) {
+      delete this.broker.nodeStates[this.node.id]
+    }
+
+    if (this.broker.lastError) {
+      delete this.broker.lastError[this.node.id]
+    }
+  }
+
   public async initialize(): Promise<Channel> {
     await this.createChannel()
     await this.assertExchange()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,8 @@ export const NODE_STATUS: { [index: string]: NodeStatus } = Object.freeze({
   Error: { fill: 'red', shape: 'dot', text: 'Error' },
   Invalid: { fill: 'red', shape: 'ring', text: 'Unable to connect' },
 })
+
+export const RECONNECT_BACKOFF = Object.freeze({
+  initialMs: 2000,
+  maxMs: 300000,
+})

--- a/src/nodes/amqp-broker.ts
+++ b/src/nodes/amqp-broker.ts
@@ -92,16 +92,14 @@ module.exports = function (RED: NodeRedApp): void {
   function getEffectiveNodeStates(
     brokerNode: AmqpBrokerNode,
   ): Record<string, BrokerNodeState> {
-    const states: Record<string, BrokerNodeState> = {
-      ...(brokerNode.nodeStates || {}),
-    }
+    const states: Record<string, BrokerNodeState> = {}
     const nodes = RED.nodes as unknown as {
       eachNode?: (callback: (node: ConfiguredAmqpNode) => void) => void
     }
 
     nodes.eachNode?.(node => {
       if (node.broker === brokerNode.id && amqpNodeTypes.has(node.type)) {
-        states[node.id] = states[node.id] || 'disconnected'
+        states[node.id] = brokerNode.nodeStates?.[node.id] || 'disconnected'
       }
     })
 

--- a/src/nodes/amqp-broker.ts
+++ b/src/nodes/amqp-broker.ts
@@ -69,9 +69,10 @@ module.exports = function (RED: NodeRedApp): void {
         status,
       }
 
-      const hasLastError = Object.keys(brokerNode.lastError || {}).length > 0
+      const activeLastError = getActiveLastError(brokerNode, states)
+      const hasLastError = Object.keys(activeLastError).length > 0
       if (hasLastError) {
-        brokerStatus.lastError = brokerNode.lastError
+        brokerStatus.lastError = activeLastError
       }
 
       return brokerStatus
@@ -104,5 +105,21 @@ module.exports = function (RED: NodeRedApp): void {
     })
 
     return states
+  }
+
+  function getActiveLastError(
+    brokerNode: AmqpBrokerNode,
+    states: Record<string, BrokerNodeState>,
+  ): AmqpBrokerNode['lastError'] {
+    const source = brokerNode.lastError || {}
+    const filtered: AmqpBrokerNode['lastError'] = {}
+
+    Object.keys(states).forEach(nodeId => {
+      if (source[nodeId]) {
+        filtered[nodeId] = source[nodeId]
+      }
+    })
+
+    return filtered
   }
 }

--- a/src/nodes/amqp-broker.ts
+++ b/src/nodes/amqp-broker.ts
@@ -1,8 +1,19 @@
 import { NodeRedApp } from 'node-red'
-import { AmqpBrokerNode, BrokerNodeState } from '../types'
+import { AmqpBrokerNode, BrokerNodeState, NodeType } from '../types'
+
+type ConfiguredAmqpNode = {
+  id: string
+  type: string
+  broker?: string
+}
 
 module.exports = function (RED: NodeRedApp): void {
   const brokerNodes: AmqpBrokerNode[] = []
+  const amqpNodeTypes = new Set<string>([
+    NodeType.AmqpIn,
+    NodeType.AmqpInManualAck,
+    NodeType.AmqpOut,
+  ])
 
   function AmqpBroker(this: AmqpBrokerNode, n): void {
     // wtf happened to the types?
@@ -39,12 +50,13 @@ module.exports = function (RED: NodeRedApp): void {
   RED.httpAdmin.get('/amqp-broker/health', (_req, res) => {
     const brokerStatuses = brokerNodes.map(brokerNode => {
       const states = getEffectiveNodeStates(brokerNode)
-      const uniqueStates = new Set(Object.values(states))
-      const status: BrokerNodeState = uniqueStates.has('errored')
+      const stateValues = Object.values(states)
+      const uniqueStates = new Set(stateValues)
+      const status: BrokerNodeState = stateValues.length > 0 && stateValues.every(state => state === 'connected')
+        ? 'connected'
+        : uniqueStates.has('errored')
         ? 'errored'
-        : uniqueStates.has('connected')
-          ? 'connected'
-          : 'disconnected'
+        : 'disconnected'
 
       const brokerStatus: {
         id: string
@@ -80,6 +92,19 @@ module.exports = function (RED: NodeRedApp): void {
   function getEffectiveNodeStates(
     brokerNode: AmqpBrokerNode,
   ): Record<string, BrokerNodeState> {
-    return brokerNode.nodeStates || {}
+    const states: Record<string, BrokerNodeState> = {
+      ...(brokerNode.nodeStates || {}),
+    }
+    const nodes = RED.nodes as unknown as {
+      eachNode?: (callback: (node: ConfiguredAmqpNode) => void) => void
+    }
+
+    nodes.eachNode?.(node => {
+      if (node.broker === brokerNode.id && amqpNodeTypes.has(node.type)) {
+        states[node.id] = states[node.id] || 'disconnected'
+      }
+    })
+
+    return states
   }
 }

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -109,12 +109,17 @@ module.exports = function (RED: NodeRedApp): void {
     // receive input reconnectCall
     this.on('input', inputListener)
     // When the server goes down
-    this.on('close', async (done: (err?: Error) => void): Promise<void> => {
+    this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
+      const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
+      const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       try {
         await amqp.close()
+        if (removed) {
+          amqp.removeBrokerNodeState()
+        }
         done && done()
       } catch (e) {
         done && done(toError(e))

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -268,7 +268,11 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpInManualAck() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
           if (reconnectOnError) {
-            await reconnect()
+            await reconnect().catch(reconnectError => {
+              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+              })
+            })
             nodeIns.status(NODE_STATUS.Invalid)
           }
         } else {
@@ -276,7 +280,11 @@ module.exports = function (RED: NodeRedApp): void {
             payload: { error: e, location: ErrorLocationEnum.ConnectError },
           })
           if (reconnectOnError) {
-            await reconnect()
+            await reconnect().catch(reconnectError => {
+              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+              })
+            })
           } else {
             nodeIns.status(NODE_STATUS.Error)
           }

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -193,6 +193,7 @@ module.exports = function (RED: NodeRedApp): void {
           channel = await amqp.initialize()
           await amqp.consume()
           if (isShuttingDown) {
+            await amqp.close().catch(() => undefined)
             return
           }
 
@@ -265,10 +266,10 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
+        await amqp.close().catch(() => undefined)
         if (isShuttingDown) {
           return
         }
-        await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -115,15 +115,23 @@ module.exports = function (RED: NodeRedApp): void {
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
+      let closeError: unknown
       try {
         await amqp.close()
+      } catch (e) {
+        closeError = e
+      } finally {
         if (removed) {
           amqp.removeBrokerNodeState()
         }
-        done && done()
-      } catch (e) {
-        done && done(toError(e))
       }
+
+      if (closeError) {
+        done && done(toError(closeError))
+        return
+      }
+
+      done && done()
     })
 
     const removeEventListeners = (): void => {

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -268,12 +268,17 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpInManualAck() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
           if (reconnectOnError) {
+            let reconnectFailed = false
             await reconnect().catch(reconnectError => {
+              reconnectFailed = true
+              nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
               })
             })
-            nodeIns.status(NODE_STATUS.Invalid)
+            if (!reconnectFailed) {
+              nodeIns.status(NODE_STATUS.Invalid)
+            }
           }
         } else {
           nodeIns.error(`AmqpInManualAck() ${e}`, {
@@ -281,6 +286,7 @@ module.exports = function (RED: NodeRedApp): void {
           })
           if (reconnectOnError) {
             await reconnect().catch(reconnectError => {
+              nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
               })

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -192,6 +192,9 @@ module.exports = function (RED: NodeRedApp): void {
         if (connection) {
           channel = await amqp.initialize()
           await amqp.consume()
+          if (isShuttingDown) {
+            return
+          }
 
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
@@ -262,6 +265,9 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
+        if (isShuttingDown) {
+          return
+        }
         await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -171,12 +171,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns).catch(() => {
-              if (typeof reconnect === 'function') {
-                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect().catch(() => undefined)
-              }
-            })
+            void initializeNode(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -12,12 +12,17 @@ import {
   AssembledMessage,
 } from '../types'
 import Amqp from '../Amqp'
+import ReconnectBackoff from '../reconnect-backoff'
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
     value: unknown,
   ): value is { code?: string; message?: string; isOperational?: boolean } =>
     typeof value === 'object' && value !== null
+  const isInvalidLoginError = (
+    err: { code?: string; message?: string },
+  ): boolean =>
+    err.code === ErrorType.InvalidLogin || /ACCESS_REFUSED/i.test(err.message || '')
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
 
@@ -32,6 +37,13 @@ module.exports = function (RED: NodeRedApp): void {
     let onConnError: (e: unknown) => Promise<void>
     let onChannelClose: () => Promise<void>
     let onChannelError: (e: unknown) => Promise<void>
+    let onConsumerCancelled: () => Promise<void>
+    const me = this
+    const reconnectBackoff = new ReconnectBackoff()
+    const nodeEmitter = me as unknown as {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void
+      off?: (event: string, listener: (...args: unknown[]) => void) => void
+    }
 
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -122,6 +134,9 @@ module.exports = function (RED: NodeRedApp): void {
       if (typeof onChannelError === 'function') {
         channel?.off?.('error', onChannelError)
       }
+      if (typeof onConsumerCancelled === 'function') {
+        nodeEmitter.off?.('amqp:consumer-cancelled', onConsumerCancelled)
+      }
     }
 
     async function initializeNode(nodeIns: Node) {
@@ -139,10 +154,16 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.log('Reconnect requested: closing AMQP resources')
           removeEventListeners()
           await amqp.close()
+          if (isShuttingDown) {
+            reconnectScheduled = false
+            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
+            return
+          }
           channel = null
           connection = null
 
-          nodeIns.log('Reconnect scheduled in 2000ms')
+          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
+          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
             reconnectScheduled = false
             if (isShuttingDown) {
@@ -156,7 +177,7 @@ module.exports = function (RED: NodeRedApp): void {
                 void reconnect()
               }
             })
-          }, 2000)
+          }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
           throw error
@@ -220,34 +241,44 @@ module.exports = function (RED: NodeRedApp): void {
             nodeIns.error(`Channel error ${e}`, { payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent } })
           }
 
+          onConsumerCancelled = async () => {
+            nodeIns.warn('AMQP consumer cancelled event received')
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+              })
+            }
+          }
+
           connection.on('close', onConnClose)
           connection.on('error', onConnError)
           channel.on('close', onChannelClose)
           channel.on('error', onChannelError)
+          nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
 
-          nodeIns.status(NODE_STATUS.Connected)
+          amqp.markConnected()
+          reconnectBackoff.reset()
         }
       } catch (e: unknown) {
         await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
-        if (
-          err.code === ErrorType.InvalidLogin ||
-          /ACCESS_REFUSED/i.test(err.message || '')
-        ) {
+        if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpInManualAck() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-        } else if (
-          err.code === ErrorType.ConnectionRefused ||
-          err.code === ErrorType.DnsResolve ||
-          err.code === ErrorType.HostNotFound ||
-          err.isOperational
-        ) {
-          reconnectOnError && (await reconnect())
-        } else {
-          nodeIns.status(NODE_STATUS.Error)
-          nodeIns.error(`AmqpInManualAck() ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
           if (reconnectOnError) {
             await reconnect()
+            nodeIns.status(NODE_STATUS.Invalid)
+          }
+        } else {
+          nodeIns.error(`AmqpInManualAck() ${e}`, {
+            payload: { error: e, location: ErrorLocationEnum.ConnectError },
+          })
+          if (reconnectOnError) {
+            await reconnect()
+          } else {
+            nodeIns.status(NODE_STATUS.Error)
           }
         }
       }

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -174,7 +174,7 @@ module.exports = function (RED: NodeRedApp): void {
             void initializeNode(nodeIns).catch(() => {
               if (typeof reconnect === 'function') {
                 nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect()
+                void reconnect().catch(() => undefined)
               }
             })
           }, reconnectDelayMs)

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -130,12 +130,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns).catch(() => {
-              if (typeof reconnect === 'function') {
-                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect().catch(() => undefined)
-              }
-            })
+            void initializeNode(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -133,7 +133,7 @@ module.exports = function (RED: NodeRedApp): void {
             void initializeNode(nodeIns).catch(() => {
               if (typeof reconnect === 'function') {
                 nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect()
+                void reconnect().catch(() => undefined)
               }
             })
           }, reconnectDelayMs)

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -68,12 +68,17 @@ module.exports = function (RED: NodeRedApp): void {
     // receive input reconnectCall
     this.on('input', inputListener)
     // When the node is re-deployed
-    this.on('close', async (done: (err?: Error) => void): Promise<void> => {
+    this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
+      const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
+      const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       try {
         await amqp.close()
+        if (removed) {
+          amqp.removeBrokerNodeState()
+        }
         done && done()
       } catch (e) {
         done && done(toError(e))

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -230,7 +230,11 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpIn() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
           if (reconnectOnError) {
-            await reconnect()
+            await reconnect().catch(reconnectError => {
+              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+              })
+            })
             nodeIns.status(NODE_STATUS.Invalid)
           }
         } else {
@@ -238,7 +242,11 @@ module.exports = function (RED: NodeRedApp): void {
             payload: { error: e, location: ErrorLocationEnum.ConnectError },
           })
           if (reconnectOnError) {
-            await reconnect()
+            await reconnect().catch(reconnectError => {
+              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+              })
+            })
           } else {
             nodeIns.status(NODE_STATUS.Error)
           }

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -230,12 +230,17 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpIn() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
           if (reconnectOnError) {
+            let reconnectFailed = false
             await reconnect().catch(reconnectError => {
+              reconnectFailed = true
+              nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
               })
             })
-            nodeIns.status(NODE_STATUS.Invalid)
+            if (!reconnectFailed) {
+              nodeIns.status(NODE_STATUS.Invalid)
+            }
           }
         } else {
           nodeIns.error(`AmqpIn() ${e}`, {
@@ -243,6 +248,7 @@ module.exports = function (RED: NodeRedApp): void {
           })
           if (reconnectOnError) {
             await reconnect().catch(reconnectError => {
+              nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
               })

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -151,6 +151,7 @@ module.exports = function (RED: NodeRedApp): void {
           channel = await amqp.initialize()
           await amqp.consume()
           if (isShuttingDown) {
+            await amqp.close().catch(() => undefined)
             return
           }
 
@@ -227,10 +228,10 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
+        await amqp.close().catch(() => undefined)
         if (isShuttingDown) {
           return
         }
-        await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -234,7 +234,7 @@ module.exports = function (RED: NodeRedApp): void {
             nodeIns.status(NODE_STATUS.Invalid)
           }
         } else {
-          nodeIns.error(`AmqpIn() ${JSON.stringify(e)}`, {
+          nodeIns.error(`AmqpIn() ${e}`, {
             payload: { error: e, location: ErrorLocationEnum.ConnectError },
           })
           if (reconnectOnError) {

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -150,6 +150,9 @@ module.exports = function (RED: NodeRedApp): void {
         if (connection) {
           channel = await amqp.initialize()
           await amqp.consume()
+          if (isShuttingDown) {
+            return
+          }
 
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
@@ -224,6 +227,9 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
+        if (isShuttingDown) {
+          return
+        }
         await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -3,12 +3,17 @@ import { Channel, ChannelModel } from 'amqplib'
 import { NODE_STATUS } from '../constants'
 import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorType, NodeType, ErrorLocationEnum } from '../types'
 import Amqp from '../Amqp'
+import ReconnectBackoff from '../reconnect-backoff'
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
     value: unknown,
   ): value is { code?: string; message?: string; isOperational?: boolean } =>
     typeof value === 'object' && value !== null
+  const isInvalidLoginError = (
+    err: { code?: string; message?: string },
+  ): boolean =>
+    err.code === ErrorType.InvalidLogin || /ACCESS_REFUSED/i.test(err.message || '')
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
 
@@ -23,6 +28,13 @@ module.exports = function (RED: NodeRedApp): void {
     let onConnError: (e: unknown) => Promise<void>
     let onChannelClose: () => Promise<void>
     let onChannelError: (e: unknown) => Promise<void>
+    let onConsumerCancelled: () => Promise<void>
+    const me = this
+    const reconnectBackoff = new ReconnectBackoff()
+    const nodeEmitter = me as unknown as {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void
+      off?: (event: string, listener: (...args: unknown[]) => void) => void
+    }
 
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -82,6 +94,9 @@ module.exports = function (RED: NodeRedApp): void {
       if (typeof onChannelError === 'function') {
         channel?.off?.('error', onChannelError)
       }
+      if (typeof onConsumerCancelled === 'function') {
+        nodeEmitter.off?.('amqp:consumer-cancelled', onConsumerCancelled)
+      }
     }
 
     async function initializeNode(nodeIns: Node) {
@@ -98,10 +113,16 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.log('Reconnect requested: closing AMQP resources')
           removeEventListeners()
           await amqp.close()
+          if (isShuttingDown) {
+            reconnectScheduled = false
+            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
+            return
+          }
           channel = null
           connection = null
 
-          nodeIns.log('Reconnect scheduled in 2000ms')
+          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
+          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
             reconnectScheduled = false
             if (isShuttingDown) {
@@ -115,7 +136,7 @@ module.exports = function (RED: NodeRedApp): void {
                 void reconnect()
               }
             })
-          }, 2000)
+          }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
           throw error
@@ -182,32 +203,45 @@ module.exports = function (RED: NodeRedApp): void {
             })
           }
 
+          onConsumerCancelled = async () => {
+            nodeIns.warn('AMQP consumer cancelled event received')
+            try {
+              await reconnect()
+            } catch (reconnectError) {
+              nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
+                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
+              })
+            }
+          }
+
           connection.on('close', onConnClose)
           connection.on('error', onConnError)
           channel.on('close', onChannelClose)
           channel.on('error', onChannelError)
+          nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
 
-          nodeIns.status(NODE_STATUS.Connected)
+          amqp.markConnected()
+          reconnectBackoff.reset()
         }
       } catch (e: unknown) {
         await amqp.close().catch(() => undefined)
         const err = isErrorLike(e) ? e : {}
-        if (
-          err.code === ErrorType.InvalidLogin ||
-          /ACCESS_REFUSED/i.test(err.message || '')
-        ) {
+        if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpIn() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-        } else if (
-          err.code === ErrorType.ConnectionRefused ||
-          err.code === ErrorType.DnsResolve ||
-          err.code === ErrorType.HostNotFound ||
-          err.isOperational
-        ) {
-          reconnectOnError && (await reconnect())
+          if (reconnectOnError) {
+            await reconnect()
+            nodeIns.status(NODE_STATUS.Invalid)
+          }
         } else {
-          nodeIns.status(NODE_STATUS.Error)
-          nodeIns.error(`AmqpIn() ${JSON.stringify(e)}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
+          nodeIns.error(`AmqpIn() ${JSON.stringify(e)}`, {
+            payload: { error: e, location: ErrorLocationEnum.ConnectError },
+          })
+          if (reconnectOnError) {
+            await reconnect()
+          } else {
+            nodeIns.status(NODE_STATUS.Error)
+          }
         }
       }
     }

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -74,15 +74,23 @@ module.exports = function (RED: NodeRedApp): void {
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
+      let closeError: unknown
       try {
         await amqp.close()
+      } catch (e) {
+        closeError = e
+      } finally {
         if (removed) {
           amqp.removeBrokerNodeState()
         }
-        done && done()
-      } catch (e) {
-        done && done(toError(e))
       }
+
+      if (closeError) {
+        done && done(toError(closeError))
+        return
+      }
+
+      done && done()
     })
     
 

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -267,12 +267,17 @@ module.exports = function (RED: NodeRedApp): void {
 
     this.on('input', inputListener)
     // When the node is re-deployed
-    this.on('close', async (done: (err?: Error) => void): Promise<void> => {
+    this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
+      const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
+      const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       try {
         await amqp.close()
+        if (removed) {
+          amqp.removeBrokerNodeState()
+        }
         done && done()
       } catch (e) {
         done && done(toError(e))

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -313,7 +313,7 @@ module.exports = function (RED: NodeRedApp): void {
             void initializeNode(nodeIns).catch(() => {
               if (typeof reconnect === 'function') {
                 nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect()
+                void reconnect().catch(() => undefined)
               }
             })
           }, reconnectDelayMs)

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -279,15 +279,23 @@ module.exports = function (RED: NodeRedApp): void {
       isShuttingDown = true
       clearTimeout(reconnectTimeout)
       removeEventListeners()
+      let closeError: unknown
       try {
         await amqp.close()
+      } catch (e) {
+        closeError = e
+      } finally {
         if (removed) {
           amqp.removeBrokerNodeState()
         }
-        done && done()
-      } catch (e) {
-        done && done(toError(e))
       }
+
+      if (closeError) {
+        done && done(toError(closeError))
+        return
+      }
+
+      done && done()
     })
 
     async function initializeNode(nodeIns: Node) {

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -333,11 +333,17 @@ module.exports = function (RED: NodeRedApp): void {
         connection = await amqp.connect()
         if (connection) {
           channel = await amqp.initialize()
+          if (isShuttingDown) {
+            return
+          }
           setupEventListeners(nodeIns)
           amqp.markConnected()
           reconnectBackoff.reset()
         }
       } catch (e) {
+        if (isShuttingDown) {
+          return
+        }
         await amqp.close().catch(() => undefined)
         await handleError(e, nodeIns)
       }

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -310,12 +310,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns).catch(() => {
-              if (typeof reconnect === 'function') {
-                nodeIns.warn('Reconnect attempt failed during initialization; retrying')
-                void reconnect().catch(() => undefined)
-              }
-            })
+            void initializeNode(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -3,12 +3,17 @@ import { NODE_STATUS } from '../constants'
 import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorLocationEnum, ErrorType, NodeType } from '../types'
 import Amqp from '../Amqp'
 import { MessageProperties, Channel, ChannelModel } from 'amqplib'
+import ReconnectBackoff from '../reconnect-backoff'
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
     value: unknown,
   ): value is { code?: string; message?: string; isOperational?: boolean } =>
     typeof value === 'object' && value !== null
+  const isInvalidLoginError = (
+    err: { code?: string; message?: string },
+  ): boolean =>
+    err.code === ErrorType.InvalidLogin || /ACCESS_REFUSED/i.test(err.message || '')
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
 
@@ -30,6 +35,7 @@ module.exports = function (RED: NodeRedApp): void {
     let onChannelClose: () => Promise<void>
     let onChannelError: (e: unknown) => Promise<void>
     const me = this
+    const reconnectBackoff = new ReconnectBackoff()
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -118,26 +124,24 @@ module.exports = function (RED: NodeRedApp): void {
 
     const handleError = async (e: unknown, nodeIns: Node): Promise<void> => {
       const err = isErrorLike(e) ? e : {}
-      if (
-        err.code === ErrorType.InvalidLogin ||
-        /ACCESS_REFUSED/i.test(err.message || '')
-      ) {
+      if (isInvalidLoginError(err)) {
         nodeIns.status(NODE_STATUS.Invalid)
         nodeIns.error(`AmqpOut() Could not connect to broker ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
-      } else if (
-        err.code === ErrorType.ConnectionRefused ||
-        err.code === ErrorType.DnsResolve ||
-        err.code === ErrorType.HostNotFound ||
-        err.isOperational
-      ) {
-        reconnectOnError && (await reconnect())
+        if (reconnectOnError) {
+          await reconnect()
+          nodeIns.status(NODE_STATUS.Invalid)
+        }
       } else {
-        nodeIns.status(NODE_STATUS.Error)
         nodeIns.error(`AmqpOut() ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
+        if (reconnectOnError) {
+          await reconnect()
+        } else {
+          nodeIns.status(NODE_STATUS.Error)
+        }
       }
     }
 
@@ -235,7 +239,7 @@ module.exports = function (RED: NodeRedApp): void {
           connection = amqp.getConnection()
           channel = amqp.getChannel()
           setupEventListeners(me)
-          me.status(NODE_STATUS.Connected)
+          amqp.markConnected()
         } catch (e) {
           await handleError(e, me)
           done && done(toError(e))
@@ -281,10 +285,16 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.log('Reconnect requested: closing AMQP resources')
           removeEventListeners()
           await amqp.close()
+          if (isShuttingDown) {
+            reconnectScheduled = false
+            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
+            return
+          }
           channel = null
           connection = null
 
-          nodeIns.log('Reconnect scheduled in 2000ms')
+          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
+          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
             reconnectScheduled = false
             if (isShuttingDown) {
@@ -298,7 +308,7 @@ module.exports = function (RED: NodeRedApp): void {
                 void reconnect()
               }
             })
-          }, 2000)
+          }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
           throw error
@@ -310,7 +320,8 @@ module.exports = function (RED: NodeRedApp): void {
         if (connection) {
           channel = await amqp.initialize()
           setupEventListeners(nodeIns)
-          nodeIns.status(NODE_STATUS.Connected)
+          amqp.markConnected()
+          reconnectBackoff.reset()
         }
       } catch (e) {
         await amqp.close().catch(() => undefined)

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -250,6 +250,8 @@ module.exports = function (RED: NodeRedApp): void {
         try {
           removeEventListeners()
           await amqp.setVhost(vhost)
+          clearTimeout(reconnectTimeout)
+          reconnectScheduled = false
           connection = amqp.getConnection()
           channel = amqp.getChannel()
           setupEventListeners(me)

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -130,7 +130,11 @@ module.exports = function (RED: NodeRedApp): void {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
         if (reconnectOnError) {
-          await reconnect()
+          await reconnect().catch(reconnectError => {
+            nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+              payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+            })
+          })
           nodeIns.status(NODE_STATUS.Invalid)
         }
       } else {
@@ -138,7 +142,11 @@ module.exports = function (RED: NodeRedApp): void {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
         if (reconnectOnError) {
-          await reconnect()
+          await reconnect().catch(reconnectError => {
+            nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
+              payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
+            })
+          })
         } else {
           nodeIns.status(NODE_STATUS.Error)
         }

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -334,6 +334,7 @@ module.exports = function (RED: NodeRedApp): void {
         if (connection) {
           channel = await amqp.initialize()
           if (isShuttingDown) {
+            await amqp.close().catch(() => undefined)
             return
           }
           setupEventListeners(nodeIns)
@@ -341,10 +342,10 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectBackoff.reset()
         }
       } catch (e) {
+        await amqp.close().catch(() => undefined)
         if (isShuttingDown) {
           return
         }
-        await amqp.close().catch(() => undefined)
         await handleError(e, nodeIns)
       }
     }

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -248,11 +248,13 @@ module.exports = function (RED: NodeRedApp): void {
 
       if (vhost) {
         try {
-          removeEventListeners()
-          await amqp.setVhost(vhost)
-          clearTimeout(reconnectTimeout)
-          reconnectScheduled = false
-          connection = amqp.getConnection()
+          clearTimeout(reconnectTimeout);
+          reconnectScheduled = false;
+
+          removeEventListeners();
+          await amqp.setVhost(vhost);
+
+          connection = amqp.getConnection();
           channel = amqp.getChannel()
           setupEventListeners(me)
           amqp.markConnected()

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -248,13 +248,13 @@ module.exports = function (RED: NodeRedApp): void {
 
       if (vhost) {
         try {
-          clearTimeout(reconnectTimeout);
-          reconnectScheduled = false;
+          clearTimeout(reconnectTimeout)
+          reconnectScheduled = false
 
-          removeEventListeners();
-          await amqp.setVhost(vhost);
+          removeEventListeners()
+          await amqp.setVhost(vhost)
 
-          connection = amqp.getConnection();
+          connection = amqp.getConnection()
           channel = amqp.getChannel()
           setupEventListeners(me)
           amqp.markConnected()

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -130,12 +130,17 @@ module.exports = function (RED: NodeRedApp): void {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
         if (reconnectOnError) {
+          let reconnectFailed = false
           await reconnect().catch(reconnectError => {
+            reconnectFailed = true
+            nodeIns.status(NODE_STATUS.Error)
             nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
               payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
             })
           })
-          nodeIns.status(NODE_STATUS.Invalid)
+          if (!reconnectFailed) {
+            nodeIns.status(NODE_STATUS.Invalid)
+          }
         }
       } else {
         nodeIns.error(`AmqpOut() ${e}`, {
@@ -143,6 +148,7 @@ module.exports = function (RED: NodeRedApp): void {
         })
         if (reconnectOnError) {
           await reconnect().catch(reconnectError => {
+            nodeIns.status(NODE_STATUS.Error)
             nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
               payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
             })

--- a/src/reconnect-backoff.ts
+++ b/src/reconnect-backoff.ts
@@ -1,0 +1,15 @@
+import { RECONNECT_BACKOFF } from './constants'
+
+export default class ReconnectBackoff {
+  private delayMs: number = RECONNECT_BACKOFF.initialMs
+
+  public nextDelayMs(): number {
+    const currentDelay = this.delayMs
+    this.delayMs = Math.min(this.delayMs * 2, RECONNECT_BACKOFF.maxMs)
+    return currentDelay
+  }
+
+  public reset(): void {
+    this.delayMs = RECONNECT_BACKOFF.initialMs
+  }
+}

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -1132,14 +1132,12 @@ describe('Amqp Class', () => {
     )
   })
 
-  it('bindQueue() logs and rethrows errors', async () => {
+  it('bindQueue() rethrows errors', async () => {
     const queue = 'queueName'
     const error = new Error('bind fail')
     const bindQueueStub = sinon.stub().rejects(error)
-    const errorStub = sinon.stub()
     amqp.channel = { bindQueue: bindQueueStub }
     amqp.q = { queue }
-    amqp.node = { error: errorStub }
 
     try {
       await amqp.bindQueue()
@@ -1147,17 +1145,14 @@ describe('Amqp Class', () => {
     } catch (e) {
       expect(e).to.equal(error)
     }
-    expect(errorStub.calledOnce).to.equal(true)
   })
 
   it('bindQueue() rethrows binding errors so consume setup can retry', async () => {
     const queue = 'queueName'
     const error = new Error('bind fail')
     const bindQueueStub = sinon.stub().rejects(error)
-    const errorStub = sinon.stub()
     amqp.channel = { bindQueue: bindQueueStub }
     amqp.q = { queue }
-    amqp.node = { error: errorStub }
 
     try {
       await amqp.bindQueue()
@@ -1165,7 +1160,6 @@ describe('Amqp Class', () => {
     } catch (e) {
       expect(e).to.equal(error)
     }
-    expect(errorStub.calledOnceWithMatch('Could not bind queue')).to.equal(true)
   })
 
   it('consume() does not register a consumer when real queue binding fails', async () => {
@@ -1189,7 +1183,6 @@ describe('Amqp Class', () => {
     }
 
     expect(consumeStub.called).to.equal(false)
-    expect(errorStub.calledWithMatch('Could not bind queue')).to.equal(true)
     expect(errorStub.calledWithMatch('Could not consume message')).to.equal(true)
   })
 

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -252,6 +252,25 @@ describe('Amqp Class', () => {
     expect(statusStub.calledWith(NODE_STATUS.Connected)).to.equal(true)
   })
 
+  it('removeBrokerNodeState() removes node runtime state and last error', () => {
+    amqp.node = { ...nodeFixture, id: 'n1' }
+    amqp.broker = {
+      ...brokerConfigFixture,
+      nodeStates: { n1: 'disconnected', n2: 'connected' },
+      lastError: {
+        n1: { message: 'stale', at: new Date().toISOString() },
+        n2: { message: 'active', at: new Date().toISOString() },
+      },
+    }
+
+    amqp.removeBrokerNodeState()
+
+    expect(amqp.broker.nodeStates.n1).to.equal(undefined)
+    expect(amqp.broker.lastError.n1).to.equal(undefined)
+    expect(amqp.broker.nodeStates.n2).to.equal('connected')
+    expect(amqp.broker.lastError.n2?.message).to.equal('active')
+  })
+
   it('shares connection among instances for same vhost', async () => {
     const connectionStub = {
       on: sinon.stub(),

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -159,6 +159,26 @@ describe('Amqp Class', () => {
     expect(broker.lastError.n1?.message).to.equal('AMQP connection closed')
   })
 
+  it('connect() does not mark node connected before channel and consumer setup complete', async () => {
+    const result = { on: sinon.stub() }
+    const broker = {
+      ...brokerConfigFixture,
+      vhost: 'vh1',
+      nodeStates: {},
+      lastError: {},
+    }
+    const statusStub = sinon.stub()
+
+    RED.nodes.getNode.returns(broker)
+    amqp.node = { ...nodeFixture, id: 'n1', log: sinon.stub(), warn: sinon.stub(), status: statusStub }
+    sinon.stub(amqplib, 'connect').resolves(result as any)
+
+    await amqp.connect()
+
+    expect(statusStub.calledWith(NODE_STATUS.Connected)).to.equal(false)
+    expect(broker.nodeStates.n1).to.equal(undefined)
+  })
+
   it('connect() errors when broker missing', async () => {
     // no broker node returned
     RED.nodes.getNode.returns(undefined)
@@ -199,6 +219,37 @@ describe('Amqp Class', () => {
 
       expect(url).to.equal('amqp://username:password@host:222/')
     })
+
+    it('uses credentials from settings when configured', () => {
+      RED.settings = {
+        MW_CONTRIB_AMQP_USERNAME: 'settings user',
+        MW_CONTRIB_AMQP_PASSWORD: 'settings/password',
+      }
+      const broker = {
+        ...brokerConfigFixture,
+        vhost: 'vhost',
+        credsFromSettings: true,
+        credentials: { username: 'ignored', password: 'ignored' },
+      }
+
+      const url = (amqp as any).getBrokerUrl(broker)
+
+      expect(url).to.equal('amqp://settings%20user:settings%2Fpassword@host:222/vhost')
+    })
+  })
+
+  it('markConnected() initializes missing broker state maps', () => {
+    const statusStub = sinon.stub()
+    amqp.node = { ...nodeFixture, id: 'n1', status: statusStub }
+    amqp.broker = { ...brokerConfigFixture }
+    delete amqp.broker.nodeStates
+    delete amqp.broker.lastError
+
+    amqp.markConnected()
+
+    expect(amqp.broker.nodeStates.n1).to.equal('connected')
+    expect(amqp.broker.lastError).to.deep.equal({})
+    expect(statusStub.calledWith(NODE_STATUS.Connected)).to.equal(true)
   })
 
   it('shares connection among instances for same vhost', async () => {
@@ -410,8 +461,10 @@ describe('Amqp Class', () => {
     const send = sinon.stub()
     const error = sinon.stub()
     const warn = sinon.stub()
+    const status = sinon.stub()
+    const emit = sinon.stub()
     const ack = sinon.stub()
-    const node = { send, error, warn, log: sinon.stub() }
+    const node = { send, error, warn, status, emit, log: sinon.stub() }
     const channel = {
       consume: function (
         _queue: string,
@@ -433,6 +486,8 @@ describe('Amqp Class', () => {
     expect(ack.called).to.equal(false)
     expect(error.called).to.equal(false)
     expect(warn.calledWithMatch('consumer was cancelled')).to.equal(true)
+    expect(status.calledWith(NODE_STATUS.Disconnected)).to.equal(true)
+    expect(emit.calledWith('amqp:consumer-cancelled')).to.equal(true)
   })
 
   it('assembleMessage retains reference and parses payload', () => {
@@ -602,6 +657,45 @@ describe('Amqp Class', () => {
       const publishedBuffer = publishStub.firstCall.args[2]
       expect(Buffer.isBuffer(publishedBuffer)).to.equal(true)
       expect(publishedBuffer.length).to.equal(0)
+    })
+
+    it('publishes Buffer payloads without copying or serializing', async () => {
+      const publishStub = sinon.stub()
+      const payload = Buffer.from('raw-buffer')
+      amqp.channel = {
+        publish: publishStub,
+      }
+
+      await amqp.publish(payload)
+
+      expect(publishStub.calledOnce).to.equal(true)
+      expect(publishStub.firstCall.args[2]).to.equal(payload)
+    })
+
+    it('publishes Uint8Array payloads as buffers', async () => {
+      const publishStub = sinon.stub()
+      const payload = new Uint8Array([1, 2, 3])
+      amqp.channel = {
+        publish: publishStub,
+      }
+
+      await amqp.publish(payload)
+
+      const publishedBuffer = publishStub.firstCall.args[2]
+      expect(Buffer.isBuffer(publishedBuffer)).to.equal(true)
+      expect([...publishedBuffer]).to.deep.equal([1, 2, 3])
+    })
+
+    it('serializes function payloads to an empty buffer', async () => {
+      const publishStub = sinon.stub()
+      amqp.channel = {
+        publish: publishStub,
+      }
+
+      await amqp.publish(() => undefined)
+
+      expect(publishStub.calledOnce).to.equal(true)
+      expect(publishStub.firstCall.args[2].length).to.equal(0)
     })
 
     it('throws a clear error for non-serializable payloads', async () => {
@@ -887,7 +981,9 @@ describe('Amqp Class', () => {
     const logStub = sinon.stub()
     const warnStub = sinon.stub()
     const errorStub = sinon.stub()
-    amqp.node = { ...nodeFixture, log: logStub, warn: warnStub, error: errorStub }
+    const statusStub = sinon.stub()
+    amqp.node = { ...nodeFixture, log: logStub, warn: warnStub, error: errorStub, status: statusStub }
+    amqp.broker = { ...brokerConfigFixture, nodeStates: {}, lastError: {} }
 
     await amqp.createChannel()
 
@@ -898,6 +994,8 @@ describe('Amqp Class', () => {
     expect(logStub.calledWithMatch('AMQP Channel closed')).to.be.true
     expect(warnStub.calledWithMatch('AMQP Message returned')).to.be.true
     expect(errorStub.calledWithMatch('AMQP Connection Error')).to.be.true
+    expect(statusStub.calledWith(NODE_STATUS.Disconnected)).to.be.true
+    expect(amqp.broker.nodeStates[nodeFixture.id]).to.equal('errored')
   })
 
   it('assertExchange()', async () => {
@@ -1034,7 +1132,7 @@ describe('Amqp Class', () => {
     )
   })
 
-  it('bindQueue() handles errors', async () => {
+  it('bindQueue() logs and rethrows errors', async () => {
     const queue = 'queueName'
     const error = new Error('bind fail')
     const bindQueueStub = sinon.stub().rejects(error)
@@ -1043,8 +1141,56 @@ describe('Amqp Class', () => {
     amqp.q = { queue }
     amqp.node = { error: errorStub }
 
-    await amqp.bindQueue()
+    try {
+      await amqp.bindQueue()
+      expect.fail('bindQueue should throw')
+    } catch (e) {
+      expect(e).to.equal(error)
+    }
     expect(errorStub.calledOnce).to.equal(true)
+  })
+
+  it('bindQueue() rethrows binding errors so consume setup can retry', async () => {
+    const queue = 'queueName'
+    const error = new Error('bind fail')
+    const bindQueueStub = sinon.stub().rejects(error)
+    const errorStub = sinon.stub()
+    amqp.channel = { bindQueue: bindQueueStub }
+    amqp.q = { queue }
+    amqp.node = { error: errorStub }
+
+    try {
+      await amqp.bindQueue()
+      expect.fail('bindQueue should throw')
+    } catch (e) {
+      expect(e).to.equal(error)
+    }
+    expect(errorStub.calledOnceWithMatch('Could not bind queue')).to.equal(true)
+  })
+
+  it('consume() does not register a consumer when real queue binding fails', async () => {
+    const assertQueueStub = sinon.stub().resolves({ queue: 'queueName' })
+    const bindQueueStub = sinon.stub().rejects(new Error('bind fail'))
+    const consumeStub = sinon.stub()
+    const errorStub = sinon.stub()
+
+    amqp.channel = {
+      assertQueue: assertQueueStub,
+      bindQueue: bindQueueStub,
+      consume: consumeStub,
+    }
+    amqp.node = { send: sinon.stub(), error: errorStub }
+
+    try {
+      await amqp.consume()
+      expect.fail('consume should throw')
+    } catch (e: any) {
+      expect(String(e.message)).to.match(/bind fail/)
+    }
+
+    expect(consumeStub.called).to.equal(false)
+    expect(errorStub.calledWithMatch('Could not bind queue')).to.equal(true)
+    expect(errorStub.calledWithMatch('Could not consume message')).to.equal(true)
   })
 
   it('consume() logs error when bindQueue fails', async () => {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -271,6 +271,34 @@ describe('Amqp Class', () => {
     expect(amqp.broker.lastError.n2?.message).to.equal('active')
   })
 
+  it('setBrokerNodeState() preserves lastError when transitioning to disconnected without new error', () => {
+    amqp.node = { ...nodeFixture, id: 'n1' }
+    amqp.broker = {
+      ...brokerConfigFixture,
+      nodeStates: { n1: 'errored' },
+      lastError: { n1: { message: 'connection dropped', at: new Date().toISOString() } },
+    }
+
+    ;(amqp as any).setBrokerNodeState('disconnected')
+
+    expect(amqp.broker.nodeStates.n1).to.equal('disconnected')
+    expect(amqp.broker.lastError.n1?.message).to.equal('connection dropped')
+  })
+
+  it('setBrokerNodeState() clears lastError when transitioning to connected', () => {
+    amqp.node = { ...nodeFixture, id: 'n1' }
+    amqp.broker = {
+      ...brokerConfigFixture,
+      nodeStates: { n1: 'disconnected' },
+      lastError: { n1: { message: 'previous error', at: new Date().toISOString() } },
+    }
+
+    ;(amqp as any).setBrokerNodeState('connected')
+
+    expect(amqp.broker.nodeStates.n1).to.equal('connected')
+    expect(amqp.broker.lastError.n1).to.equal(undefined)
+  })
+
   it('shares connection among instances for same vhost', async () => {
     const connectionStub = {
       on: sinon.stub(),
@@ -1684,7 +1712,7 @@ describe('Amqp Class', () => {
       expect(connectionStub.close.called).to.be.false
       expect(amqp.node.status.calledWith(NODE_STATUS.Disconnected)).to.be.true
       expect(amqp.broker.nodeStates[nodeFixture.id]).to.equal('disconnected')
-      expect(amqp.broker.lastError[nodeFixture.id]).to.equal(undefined)
+      expect(amqp.broker.lastError[nodeFixture.id]?.message).to.equal('previous error')
     })
 
     it('removes the connection from the pool when count reaches zero', async () => {

--- a/test/nodes/amqp-broker.spec.ts
+++ b/test/nodes/amqp-broker.spec.ts
@@ -240,6 +240,67 @@ describe('amqp-broker Node', () => {
       })
     })
 
+    it('should ignore stale lastError entries for nodes not present in the active flow', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
+      const flow = [
+        {
+          id: 'b1',
+          type: 'amqp-broker',
+          name: 'broker 1',
+          nodeStates: {
+            activeNode: 'errored',
+            deletedNode: 'errored',
+          },
+          lastError: {
+            activeNode: {
+              message: 'Active node error',
+              at: '2026-03-02T00:00:00.000Z',
+            },
+            deletedNode: {
+              message: 'Stale node error',
+              at: '2026-03-02T00:00:00.000Z',
+            },
+          },
+        },
+        {
+          id: 'activeNode',
+          type: 'amqp-in-manual-ack',
+          broker: 'b1',
+          name: 'active input',
+        },
+      ]
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
+        helper
+          .request()
+          .get('/amqp-broker/health')
+          .expect(503)
+          .end((err, res) => {
+            try {
+              if (err) return done(err)
+              expect(res.body).to.deep.equal({
+                overallStatus: 'unhealthy',
+                brokers: [
+                  {
+                    id: 'b1',
+                    name: 'broker 1',
+                    status: 'errored',
+                    lastError: {
+                      activeNode: {
+                        message: 'Active node error',
+                        at: '2026-03-02T00:00:00.000Z',
+                      },
+                    },
+                  },
+                ],
+              })
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+      })
+    })
+
     it('should return 503 when a broker has an errored node state', done => {
       sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
@@ -292,6 +353,7 @@ describe('amqp-broker Node', () => {
     })
 
     it('should return 503 with disconnected status and lastError when a connection closes unexpectedly', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -305,8 +367,9 @@ describe('amqp-broker Node', () => {
             },
           },
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         helper
           .request()
           .get('/amqp-broker/health')

--- a/test/nodes/amqp-broker.spec.ts
+++ b/test/nodes/amqp-broker.spec.ts
@@ -47,6 +47,7 @@ describe('amqp-broker Node', () => {
     })
 
     it('should return 200 when all brokers are connected', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -60,8 +61,10 @@ describe('amqp-broker Node', () => {
           name: 'broker 2',
           nodeStates: { n2: 'connected' },
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
+        { id: 'n2', type: 'amqp-in-manual-ack', broker: 'b2', name: 'input 2' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         helper
           .request()
           .get('/amqp-broker/health')
@@ -85,6 +88,7 @@ describe('amqp-broker Node', () => {
     })
 
     it('should return 503 when one broker is disconnected', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -98,8 +102,10 @@ describe('amqp-broker Node', () => {
           name: 'broker 2',
           nodeStates: { n2: 'disconnected' },
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
+        { id: 'n2', type: 'amqp-in-manual-ack', broker: 'b2', name: 'input 2' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         helper
           .request()
           .get('/amqp-broker/health')
@@ -196,7 +202,46 @@ describe('amqp-broker Node', () => {
       })
     })
 
+    it('should ignore stale nodeStates for nodes not present in the active flow', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
+      const flow = [
+        {
+          id: 'b1',
+          type: 'amqp-broker',
+          name: 'broker 1',
+          nodeStates: {
+            deletedNode: 'connected',
+          },
+        },
+        {
+          id: 'amqpInManualAck',
+          type: 'amqp-in-manual-ack',
+          broker: 'b1',
+          name: 'manual ack input',
+        },
+      ]
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
+        helper
+          .request()
+          .get('/amqp-broker/health')
+          .expect(503)
+          .end((err, res) => {
+            try {
+              if (err) return done(err)
+              expect(res.body).to.deep.equal({
+                overallStatus: 'unhealthy',
+                brokers: [{ id: 'b1', name: 'broker 1', status: 'disconnected' }],
+              })
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+      })
+    })
+
     it('should return 503 when a broker has an errored node state', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -211,8 +256,9 @@ describe('amqp-broker Node', () => {
             },
           },
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         helper
           .request()
           .get('/amqp-broker/health')
@@ -293,6 +339,7 @@ describe('amqp-broker Node', () => {
     })
 
     it('should return 503 when a broker has no nodeStates property', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -305,8 +352,10 @@ describe('amqp-broker Node', () => {
           type: 'amqp-broker',
           name: 'broker 2',
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
+        { id: 'n2', type: 'amqp-in-manual-ack', broker: 'b2', name: 'input 2' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         helper
           .request()
           .get('/amqp-broker/health')
@@ -366,6 +415,7 @@ describe('amqp-broker Node', () => {
     })
 
     it('should reflect the removal of a broker', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
       const flow = [
         {
           id: 'b1',
@@ -379,8 +429,10 @@ describe('amqp-broker Node', () => {
           name: 'broker 2',
           nodeStates: { n2: 'connected' },
         },
+        { id: 'n1', type: 'amqp-in-manual-ack', broker: 'b1', name: 'input 1' },
+        { id: 'n2', type: 'amqp-in-manual-ack', broker: 'b2', name: 'input 2' },
       ]
-      helper.load(amqpBroker, flow, () => {
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
         const b2 = helper.getNode('b2')
         b2.close()
         // No setTimeout needed, the 'close' event is synchronous

--- a/test/nodes/amqp-broker.spec.ts
+++ b/test/nodes/amqp-broker.spec.ts
@@ -4,7 +4,9 @@ export {}
 const { expect } = require('chai')
 const sinon = require('sinon')
 const helper = require('node-red-node-test-helper')
+const Amqp = require('../../src/Amqp').default
 const amqpBroker = require('../../src/nodes/amqp-broker')
+const amqpInManualAck = require('../../src/nodes/amqp-in-manual-ack')
 
 helper.init(require.resolve('node-red'))
 
@@ -114,6 +116,80 @@ describe('amqp-broker Node', () => {
               })
               done()
             } catch(e) {
+              done(e)
+            }
+          })
+      })
+    })
+
+    it('should return 503 when one node on a broker is disconnected', done => {
+      const flow = [
+        {
+          id: 'b1',
+          type: 'amqp-broker',
+          name: 'broker 1',
+          nodeStates: {
+            amqpInManualAck: 'disconnected',
+            amqpOut: 'connected',
+          },
+        },
+      ]
+      helper.load(amqpBroker, flow, () => {
+        helper
+          .request()
+          .get('/amqp-broker/health')
+          .expect(503)
+          .end((err, res) => {
+            try {
+              if (err) return done(err)
+              expect(res.body).to.deep.equal({
+                overallStatus: 'unhealthy',
+                brokers: [
+                  { id: 'b1', name: 'broker 1', status: 'disconnected' },
+                ],
+              })
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+      })
+    })
+
+    it('should return 503 when a configured broker node has not reported state yet', done => {
+      sinon.stub(Amqp.prototype, 'connect').returns(new Promise(() => undefined))
+      const flow = [
+        {
+          id: 'b1',
+          type: 'amqp-broker',
+          name: 'broker 1',
+          nodeStates: {
+            amqpOut: 'connected',
+          },
+        },
+        {
+          id: 'amqpInManualAck',
+          type: 'amqp-in-manual-ack',
+          broker: 'b1',
+          name: 'manual ack input',
+        },
+      ]
+      helper.load([amqpBroker, amqpInManualAck], flow, () => {
+        helper
+          .request()
+          .get('/amqp-broker/health')
+          .expect(503)
+          .end((err, res) => {
+            try {
+              if (err) return done(err)
+              expect(res.body).to.deep.equal({
+                overallStatus: 'unhealthy',
+                brokers: [
+                  { id: 'b1', name: 'broker 1', status: 'disconnected' },
+                ],
+              })
+              done()
+            } catch (e) {
               done(e)
             }
           })

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -902,8 +902,12 @@ describe('amqp-in-manual-ack Node', () => {
       await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
       const amqpInNode = helper.getNode('n1')
       const callErrors: unknown[] = []
+      const callStatuses: unknown[] = []
       amqpInNode.on('call:error', call => {
         callErrors.push(call.args[0])
+      })
+      amqpInNode.on('call:status', call => {
+        callStatuses.push(call.args[0])
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
@@ -911,6 +915,11 @@ describe('amqp-in-manual-ack Node', () => {
       expect(unhandledReason).to.equal(undefined)
       expect(
         callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+      expect(
+        callStatuses.some(
+          status => status && typeof status === 'object' && (status as { text?: string }).text === NODE_STATUS.Error.text,
+        ),
       ).to.be.true
     } finally {
       process.removeListener('unhandledRejection', onUnhandledRejection)

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -864,6 +864,39 @@ describe('amqp-in-manual-ack Node', () => {
     }
   })
 
+  it('does not emit unhandled rejection when reconnect fails during initialization error handling', async function () {
+    sinon.stub(Amqp.prototype, 'connect').rejects(new Error('initial connect failed'))
+    sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+
+    const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+    flow[0].reconnectOnError = true
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+      const amqpInNode = helper.getNode('n1')
+      const callErrors: unknown[] = []
+      amqpInNode.on('call:error', call => {
+        callErrors.push(call.args[0])
+      })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(unhandledReason).to.equal(undefined)
+      expect(
+        callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+  })
+
   it('backs off repeated reconnect initialization failures', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -333,7 +333,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
     sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
     sinon.stub(Amqp.prototype, 'consume').resolves()
-    sinon.stub(Amqp.prototype, 'close').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load([amqpInManualAck, amqpBroker], amqpInManualAckFlowFixture, credentialsFixture)
     const node = helper.getNode('n1')
@@ -350,6 +350,7 @@ describe('amqp-in-manual-ack Node', () => {
       return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
     })
     expect(hasErrorOrInvalid).to.be.false
+    expect(closeStub.called).to.be.true
   })
 
   it('should reconnect on input message', done => {

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -452,6 +452,26 @@ describe('amqp-in-manual-ack Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when node is permanently deleted', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+    const node = helper.getNode('n1')
+    await node.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('reconnects on channel close even when reconnectOnError is false', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -505,6 +505,26 @@ describe('amqp-in-manual-ack Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when delete close fails', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+    const node = helper.getNode('n1')
+    await node.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('removes broker node state when node is permanently deleted', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -317,7 +317,12 @@ describe('amqp-in-manual-ack Node', () => {
 
   it('does not ack reconnect control messages', done => {
     const ackStub = sinon.stub(Amqp.prototype, 'ack')
-    const closeStub = sinon.stub(Amqp.prototype, 'close')
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
     const flow = [
       { id: 'n1', type: NodeType.AmqpInManualAck, name: 'test name', broker: 'b1', wires: [[]] },
       { id: 'b1', type: 'amqp-broker', name: 'test broker' },
@@ -335,7 +340,12 @@ describe('amqp-in-manual-ack Node', () => {
   it('prioritizes reconnect control over manualAck instructions', done => {
     const ackStub = sinon.stub(Amqp.prototype, 'ack')
     const nackStub = sinon.stub(Amqp.prototype, 'nack')
-    const closeStub = sinon.stub(Amqp.prototype, 'close')
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
     const flow = [
       { id: 'n1', type: NodeType.AmqpInManualAck, name: 'test name', broker: 'b1', wires: [[]] },
       { id: 'b1', type: 'amqp-broker', name: 'test broker' },
@@ -438,7 +448,7 @@ describe('amqp-in-manual-ack Node', () => {
       credentialsFixture,
     )
     const onCallback = connectionMock.on.withArgs('close').getCall(0).args[1]
-    onCallback()
+    await onCallback()
     expect(closeStub.calledOnce).to.be.true
   })
 
@@ -455,11 +465,11 @@ describe('amqp-in-manual-ack Node', () => {
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
-    flow[1].reconnectOnError = false
+    flow[0].reconnectOnError = false
 
     await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
     const onCallback = channelMock.on.withArgs('close').getCall(0).args[1]
-    onCallback()
+    await onCallback()
     expect(closeStub.calledOnce).to.be.true
   })
 
@@ -597,6 +607,42 @@ describe('amqp-in-manual-ack Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      let releaseClose: () => void = () => undefined
+      const closeDuringReconnect = new Promise<void>(resolve => {
+        releaseClose = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(closeDuringReconnect)
+      closeStub.onSecondCall().resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+
+      const n1 = helper.getNode('n1')
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      const reconnectPromise = onConnClose()
+      await n1.close()
+      releaseClose()
+      await reconnectPromise
+      await clock.tickAsync(2001)
+
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('coalesces duplicate reconnect triggers into a single reconnect cycle', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
@@ -664,7 +710,26 @@ describe('amqp-in-manual-ack Node', () => {
       credentialsFixture,
     )
     const onCallback = channelMock.on.withArgs('close').getCall(0).args[1]
-    onCallback()
+    await onCallback()
+    expect(closeStub.calledOnce).to.be.true
+  })
+
+  it('reconnects when AMQP consumer is cancelled', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close')
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+    const node = helper.getNode('n1')
+    node.emit('amqp:consumer-cancelled')
+    await new Promise(resolve => setImmediate(resolve))
     expect(closeStub.calledOnce).to.be.true
   })
 
@@ -677,7 +742,7 @@ describe('amqp-in-manual-ack Node', () => {
     const closeStub = sinon.stub(Amqp.prototype, 'close')
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
-    flow[1].reconnectOnError = false
+    flow[0].reconnectOnError = false
 
     await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
     const onCallback = channelMock.on.withArgs('error').getCall(0).args[1]
@@ -714,12 +779,23 @@ describe('amqp-in-manual-ack Node', () => {
     const closeStub = sinon.stub(Amqp.prototype, 'close');
 
     const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture));
-    flow[1].reconnectOnError = false;
+    flow[0].reconnectOnError = false;
 
     await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+    const amqpInNode = helper.getNode('n1')
+    closeStub.resetHistory()
+
+    const errorPromise = new Promise<void>(resolve => {
+      amqpInNode.on('call:error', () => {
+        resolve()
+      })
+    })
+
     const onCallback = connectionMock.on.withArgs('error').getCall(0).args[1]
     onCallback('connection error')
-    expect(closeStub.called).to.be.false
+    await errorPromise
+
+    expect(closeStub.notCalled).to.be.true
   });
 
   it('reconnects on connection error without error argument when reconnectOnError is true', async function () {
@@ -739,6 +815,86 @@ describe('amqp-in-manual-ack Node', () => {
     expect(closeStub.calledOnce).to.be.true
   });
 
+  it('retries initialization on unclassified connect errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('retries initialization on auth errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(new CustomError(ErrorType.InvalidLogin))
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('backs off repeated reconnect initialization failures', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().rejects(transientError)
+      connectStub.onThirdCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('does not reconnect on initialization failure when reconnectOnError is false', async function () {
     const error = new Error('Initial connection failed');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -749,7 +905,9 @@ describe('amqp-in-manual-ack Node', () => {
     sinon.stub(Amqp.prototype, 'initialize').resolves(initChannelMock as any)
     sinon.stub(Amqp.prototype, 'consume').resolves()
 
-    await helper.load([amqpInManualAck, amqpBroker], amqpInManualAckFlowFixture, credentialsFixture);
+    const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+    flow[0].reconnectOnError = false
+    await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture);
     expect(connectStub.callCount).to.equal(1);
   });
 })

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -300,6 +300,58 @@ describe('amqp-in-manual-ack Node', () => {
     expect(closeStub.called).to.be.true
   })
 
+  it('does not register listeners or mark connected when node closes during initialization', async function () {
+    let resolveInitialize: (value: unknown) => void
+    const initializePromise = new Promise(resolve => {
+      resolveInitialize = resolve
+    })
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const markConnectedStub = sinon.stub(Amqp.prototype, 'markConnected')
+
+    await helper.load([amqpInManualAck, amqpBroker], amqpInManualAckFlowFixture, credentialsFixture)
+    const node = helper.getNode('n1')
+    const closePromise = node.close()
+    resolveInitialize!(channelMock)
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(markConnectedStub.called).to.be.false
+    expect(connectionMock.on.called).to.be.false
+    expect(channelMock.on.called).to.be.false
+  })
+
+  it('does not set error or invalid status when initialization fails during shutdown', async function () {
+    let rejectInitialize: (reason?: unknown) => void
+    const initializePromise = new Promise((_, reject) => {
+      rejectInitialize = reject
+    })
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load([amqpInManualAck, amqpBroker], amqpInManualAckFlowFixture, credentialsFixture)
+    const node = helper.getNode('n1')
+    const statuses: unknown[] = []
+    node.on('call:status', call => statuses.push(call.args[0]))
+
+    const closePromise = node.close()
+    rejectInitialize!(new Error('init failed during shutdown'))
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const hasErrorOrInvalid = statuses.some(status => {
+      const text = status && typeof status === 'object' ? (status as { text?: string }).text : ''
+      return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
+    })
+    expect(hasErrorOrInvalid).to.be.false
+  })
+
   it('should reconnect on input message', done => {
     const connectStub = sinon.stub(Amqp.prototype, 'connect')
     const closeStub = sinon.stub(Amqp.prototype, 'close')

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -207,6 +207,31 @@ describe('amqp-in Node', () => {
     )
   })
 
+  it('logs Error details when connection setup fails', function (done) {
+    sinon.stub(Amqp.prototype, 'connect').rejects(new Error('socket exploded'))
+
+    helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+      function () {
+        const amqpInNode = helper.getNode('n1')
+        amqpInNode.on('call:error', call => {
+          const message = String(call.args[0])
+          if (message.startsWith('AmqpIn()')) {
+            try {
+              expect(message).to.include('Error: socket exploded')
+              expect(message).to.not.include('{}')
+              done()
+            } catch (err) {
+              done(err)
+            }
+          }
+        })
+      },
+    )
+  })
+
   it('handles non-object connect errors', function (done) {
     const connectStub = sinon.stub(Amqp.prototype, 'connect').throws('boom')
     helper.load(

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -498,6 +498,42 @@ describe('amqp-in Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      let releaseClose: () => void = () => undefined
+      const closeDuringReconnect = new Promise<void>(resolve => {
+        releaseClose = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(closeDuringReconnect)
+      closeStub.onSecondCall().resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+
+      const n1 = helper.getNode('n1')
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      const reconnectPromise = onConnClose()
+      await n1.close()
+      releaseClose()
+      await reconnectPromise
+      await clock.tickAsync(2001)
+
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('coalesces duplicate reconnect triggers into a single reconnect cycle', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
@@ -539,7 +575,7 @@ describe('amqp-in Node', () => {
       credentialsFixture
     );
     const onCallback = channelMock.on.withArgs('close').getCall(0).args[1];
-    onCallback('channel closed');
+    await onCallback('channel closed');
     expect(closeStub.calledOnce).to.be.true;
   });
 
@@ -560,9 +596,28 @@ describe('amqp-in Node', () => {
       credentialsFixture
     );
     const onCallback = channelMock.on.withArgs('close').getCall(0).args[1];
-    onCallback('channel closed');
+    await onCallback('channel closed');
     expect(closeStub.calledOnce).to.be.true;
   });
+
+  it('reconnects when AMQP consumer is cancelled', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close')
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture
+    )
+    const amqpInNode = helper.getNode('n1')
+    amqpInNode.emit('amqp:consumer-cancelled')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(closeStub.calledOnce).to.be.true
+  })
 
   it('handles channel error', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() };
@@ -624,6 +679,86 @@ describe('amqp-in Node', () => {
 
     expect(closeStub.notCalled).to.be.true;
   });
+
+  it('retries initialization on unclassified connect errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('retries initialization on auth errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(new CustomError(ErrorType.InvalidLogin))
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('backs off repeated reconnect initialization failures', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().rejects(transientError)
+      connectStub.onThirdCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
+  })
 
   it('does not auto-ack when noAck is false', async function () {
     const ackStub = sinon.stub(Amqp.prototype, 'ack');

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -322,7 +322,7 @@ describe('amqp-in Node', () => {
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
     sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
     sinon.stub(Amqp.prototype, 'consume').resolves()
-    sinon.stub(Amqp.prototype, 'close').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load([amqpIn, amqpBroker], amqpInFlowFixture, credentialsFixture)
     const amqpInNode = helper.getNode('n1')
@@ -339,6 +339,7 @@ describe('amqp-in Node', () => {
       return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
     })
     expect(hasErrorOrInvalid).to.be.false
+    expect(closeStub.called).to.be.true
   })
 
   it('does not register listeners or report connected when consume setup fails', async function () {

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -289,6 +289,58 @@ describe('amqp-in Node', () => {
     expect(closeStub.called).to.be.true
   })
 
+  it('does not register listeners or mark connected when node closes during initialization', async function () {
+    let resolveInitialize: (value: unknown) => void
+    const initializePromise = new Promise(resolve => {
+      resolveInitialize = resolve
+    })
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const markConnectedStub = sinon.stub(Amqp.prototype, 'markConnected')
+
+    await helper.load([amqpIn, amqpBroker], amqpInFlowFixture, credentialsFixture)
+    const amqpInNode = helper.getNode('n1')
+    const closePromise = amqpInNode.close()
+    resolveInitialize!(channelMock)
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(markConnectedStub.called).to.be.false
+    expect(connectionMock.on.called).to.be.false
+    expect(channelMock.on.called).to.be.false
+  })
+
+  it('does not set error or invalid status when initialization fails during shutdown', async function () {
+    let rejectInitialize: (reason?: unknown) => void
+    const initializePromise = new Promise((_, reject) => {
+      rejectInitialize = reject
+    })
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load([amqpIn, amqpBroker], amqpInFlowFixture, credentialsFixture)
+    const amqpInNode = helper.getNode('n1')
+    const statuses: unknown[] = []
+    amqpInNode.on('call:status', call => statuses.push(call.args[0]))
+
+    const closePromise = amqpInNode.close()
+    rejectInitialize!(new Error('init failed during shutdown'))
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const hasErrorOrInvalid = statuses.some(status => {
+      const text = status && typeof status === 'object' ? (status as { text?: string }).text : ''
+      return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
+    })
+    expect(hasErrorOrInvalid).to.be.false
+  })
+
   it('does not register listeners or report connected when consume setup fails', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -523,6 +523,26 @@ describe('amqp-in Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when node is permanently deleted', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub(), consume: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+    const amqpInNode = helper.getNode('n1')
+    await amqpInNode.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -576,6 +576,26 @@ describe('amqp-in Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when delete close fails', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub(), consume: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+    const amqpInNode = helper.getNode('n1')
+    await amqpInNode.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('removes broker node state when node is permanently deleted', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub(), consume: sinon.stub() }

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -754,6 +754,39 @@ describe('amqp-in Node', () => {
     }
   })
 
+  it('does not emit unhandled rejection when reconnect fails during initialization error handling', async function () {
+    sinon.stub(Amqp.prototype, 'connect').rejects(new Error('initial connect failed'))
+    sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+
+    const flow = JSON.parse(JSON.stringify(amqpInFlowFixture))
+    flow[0].reconnectOnError = true
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
+      const amqpInNode = helper.getNode('n1')
+      const callErrors: unknown[] = []
+      amqpInNode.on('call:error', call => {
+        callErrors.push(call.args[0])
+      })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(unhandledReason).to.equal(undefined)
+      expect(
+        callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+  })
+
   it('backs off repeated reconnect initialization failures', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -792,8 +792,12 @@ describe('amqp-in Node', () => {
       await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
       const amqpInNode = helper.getNode('n1')
       const callErrors: unknown[] = []
+      const callStatuses: unknown[] = []
       amqpInNode.on('call:error', call => {
         callErrors.push(call.args[0])
+      })
+      amqpInNode.on('call:status', call => {
+        callStatuses.push(call.args[0])
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
@@ -801,6 +805,11 @@ describe('amqp-in Node', () => {
       expect(unhandledReason).to.equal(undefined)
       expect(
         callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+      expect(
+        callStatuses.some(
+          status => status && typeof status === 'object' && (status as { text?: string }).text === NODE_STATUS.Error.text,
+        ),
       ).to.be.true
     } finally {
       process.removeListener('unhandledRejection', onUnhandledRejection)

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -863,15 +863,22 @@ describe('amqp-out Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
-  it('clears pending reconnect timer when switching vhost dynamically', async function () {
+  it('clears pending reconnect timer before switching vhost dynamically', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {
       const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
       const channelMock = { on: sinon.stub(), off: sinon.stub() }
+
       const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
       sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
       sinon.stub(Amqp.prototype, 'close').resolves()
-      sinon.stub(Amqp.prototype, 'setVhost').resolves()
+
+      let releaseSetVhost: () => void = () => undefined
+      const setVhostPromise = new Promise<void>(resolve => {
+        releaseSetVhost = resolve
+      })
+
+      sinon.stub(Amqp.prototype, 'setVhost').returns(setVhostPromise as any)
       sinon.stub(Amqp.prototype, 'publish').resolves()
       sinon.stub(Amqp.prototype, 'getConnection').returns(connectionMock as any)
       sinon.stub(Amqp.prototype, 'getChannel').returns(channelMock as any)
@@ -884,13 +891,22 @@ describe('amqp-out Node', () => {
 
       const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
       await onConnClose()
+
+      // Timer is now scheduled for 2000ms.
       await clock.tickAsync(1000)
 
       const amqpOutNode = helper.getNode('n1')
       amqpOutNode.receive({ payload: 'foo', vhost: 'vh2' })
+
+      // Advance beyond the original reconnect deadline while setVhost is still pending.
+      await clock.tickAsync(2000)
+
+      // No reconnect should have fired while the dynamic vhost switch is in progress.
+      expect(connectStub.calledOnce).to.be.true
+
+      releaseSetVhost()
       await clock.tickAsync(0)
 
-      await clock.tickAsync(3000)
       expect(connectStub.calledOnce).to.be.true
     } finally {
       clock.restore()

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -812,6 +812,41 @@ describe('amqp-out Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      let releaseClose: () => void = () => undefined
+      const closeDuringReconnect = new Promise<void>(resolve => {
+        releaseClose = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(closeDuringReconnect)
+      closeStub.onSecondCall().resolves()
+
+      await helper.load(
+        [amqpOut, amqpBroker],
+        amqpOutFlowFixture,
+        credentialsFixture,
+      )
+
+      const n1 = helper.getNode('n1')
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      const reconnectPromise = onConnClose()
+      await n1.close()
+      releaseClose()
+      await reconnectPromise
+      await clock.tickAsync(2001)
+
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('coalesces duplicate reconnect triggers into a single reconnect cycle', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
@@ -836,6 +871,83 @@ describe('amqp-out Node', () => {
     await clock.tickAsync(2001)
     expect(connectStub.callCount).to.equal(2)
     clock.restore()
+  })
+
+  it('retries initialization on unclassified connect errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('retries initialization on auth errors when reconnectOnError is true', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(new CustomError(ErrorType.InvalidLogin))
+      connectStub.onSecondCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+
+      expect(connectStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('backs off repeated reconnect initialization failures', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const transientError = new Error('socket hang up')
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().rejects(transientError)
+      connectStub.onSecondCall().rejects(transientError)
+      connectStub.onThirdCall().resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+      flow[0].reconnectOnError = true
+
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      expect(connectStub.callCount).to.equal(1)
+
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
   })
 
   it('should handle connection errors', function (done) {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -423,7 +423,7 @@ describe('amqp-out Node', () => {
     })
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
     sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
-    sinon.stub(Amqp.prototype, 'close').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
 
     await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
     const amqpOutNode = helper.getNode('n1')
@@ -440,6 +440,7 @@ describe('amqp-out Node', () => {
       return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
     })
     expect(hasErrorOrInvalid).to.be.false
+    expect(closeStub.called).to.be.true
   })
 
   it('closes cleanly before listeners are assigned', async function () {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -863,6 +863,25 @@ describe('amqp-out Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when delete close fails', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+    const amqpOutNode = helper.getNode('n1')
+    await amqpOutNode.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('removes broker node state when node is permanently deleted', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -920,6 +920,38 @@ describe('amqp-out Node', () => {
     }
   })
 
+  it('does not emit unhandled rejection when reconnect fails during initialization error handling', async function () {
+    sinon.stub(Amqp.prototype, 'connect').rejects(new Error('initial connect failed'))
+    sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'close').rejects(new Error('close failed'))
+
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[0].reconnectOnError = true
+
+    let unhandledReason: unknown
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledReason = reason
+    }
+    process.once('unhandledRejection', onUnhandledRejection)
+    try {
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      const amqpOutNode = helper.getNode('n1')
+      const callErrors: unknown[] = []
+      amqpOutNode.on('call:error', call => {
+        callErrors.push(call.args[0])
+      })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(unhandledReason).to.equal(undefined)
+      expect(
+        callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection)
+    }
+  })
+
   it('backs off repeated reconnect initialization failures', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -812,6 +812,25 @@ describe('amqp-out Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('removes broker node state when node is permanently deleted', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+    const amqpOutNode = helper.getNode('n1')
+    await amqpOutNode.close(true)
+
+    expect(removeBrokerNodeStateStub.calledOnce).to.be.true
+  })
+
   it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -956,8 +956,12 @@ describe('amqp-out Node', () => {
       await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
       const amqpOutNode = helper.getNode('n1')
       const callErrors: unknown[] = []
+      const callStatuses: unknown[] = []
       amqpOutNode.on('call:error', call => {
         callErrors.push(call.args[0])
+      })
+      amqpOutNode.on('call:status', call => {
+        callStatuses.push(call.args[0])
       })
 
       await new Promise(resolve => setTimeout(resolve, 50))
@@ -965,6 +969,11 @@ describe('amqp-out Node', () => {
       expect(unhandledReason).to.equal(undefined)
       expect(
         callErrors.some(error => /Reconnect failed during initialization/i.test(String(error))),
+      ).to.be.true
+      expect(
+        callStatuses.some(
+          status => status && typeof status === 'object' && (status as { text?: string }).text === NODE_STATUS.Error.text,
+        ),
       ).to.be.true
     } finally {
       process.removeListener('unhandledRejection', onUnhandledRejection)

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -392,6 +392,56 @@ describe('amqp-out Node', () => {
     expect(closeStub.called).to.be.true
   })
 
+  it('does not register listeners or mark connected when node closes during initialization', async function () {
+    let resolveInitialize: (value: unknown) => void
+    const initializePromise = new Promise(resolve => {
+      resolveInitialize = resolve
+    })
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    const markConnectedStub = sinon.stub(Amqp.prototype, 'markConnected')
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+    const closePromise = amqpOutNode.close()
+    resolveInitialize!(channelMock)
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(markConnectedStub.called).to.be.false
+    expect(connectionMock.on.called).to.be.false
+    expect(channelMock.on.called).to.be.false
+  })
+
+  it('does not set error or invalid status when initialization fails during shutdown', async function () {
+    let rejectInitialize: (reason?: unknown) => void
+    const initializePromise = new Promise((_, reject) => {
+      rejectInitialize = reject
+    })
+    sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
+    sinon.stub(Amqp.prototype, 'initialize').returns(initializePromise as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+    const statuses: unknown[] = []
+    amqpOutNode.on('call:status', call => statuses.push(call.args[0]))
+
+    const closePromise = amqpOutNode.close()
+    rejectInitialize!(new Error('init failed during shutdown'))
+    await closePromise
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const hasErrorOrInvalid = statuses.some(status => {
+      const text = status && typeof status === 'object' ? (status as { text?: string }).text : ''
+      return text === NODE_STATUS.Error.text || text === NODE_STATUS.Invalid.text
+    })
+    expect(hasErrorOrInvalid).to.be.false
+  })
+
   it('closes cleanly before listeners are assigned', async function () {
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub(), close: sinon.stub() } as any)
     sinon.stub(Amqp.prototype, 'initialize').returns(new Promise(() => undefined) as any)

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -863,6 +863,40 @@ describe('amqp-out Node', () => {
     expect(closeStub.calledOnce).to.be.true
   })
 
+  it('clears pending reconnect timer when switching vhost dynamically', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+      sinon.stub(Amqp.prototype, 'setVhost').resolves()
+      sinon.stub(Amqp.prototype, 'publish').resolves()
+      sinon.stub(Amqp.prototype, 'getConnection').returns(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'getChannel').returns(channelMock as any)
+
+      await helper.load(
+        [amqpOut, amqpBroker],
+        amqpOutFlowFixture,
+        credentialsFixture,
+      )
+
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      await onConnClose()
+      await clock.tickAsync(1000)
+
+      const amqpOutNode = helper.getNode('n1')
+      amqpOutNode.receive({ payload: 'foo', vhost: 'vh2' })
+      await clock.tickAsync(0)
+
+      await clock.tickAsync(3000)
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('removes broker node state when delete close fails', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }

--- a/test/reconnect-backoff.spec.ts
+++ b/test/reconnect-backoff.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export {}
+const { expect } = require('chai')
+const ReconnectBackoff = require('../src/reconnect-backoff').default
+
+describe('ReconnectBackoff', () => {
+  it('caps reconnect delay at five minutes', () => {
+    const backoff = new ReconnectBackoff()
+    const delays = Array.from({ length: 12 }, () => backoff.nextDelayMs())
+
+    expect(delays).to.deep.equal([
+      2000,
+      4000,
+      8000,
+      16000,
+      32000,
+      64000,
+      128000,
+      256000,
+      300000,
+      300000,
+      300000,
+      300000,
+    ])
+  })
+
+  it('resets reconnect delay to the initial value', () => {
+    const backoff = new ReconnectBackoff()
+
+    backoff.nextDelayMs()
+    backoff.nextDelayMs()
+    backoff.reset()
+
+    expect(backoff.nextDelayMs()).to.equal(2000)
+  })
+})


### PR DESCRIPTION
## Summary
- Retry AMQP initialization on auth and transient errors with exponential backoff capped at 5 minutes.
- Treat consumer cancellation and late reconnect shutdown races as reconnect-worthy failures.
- Delay `connected` status until channel and consumer setup complete, and keep broker health aligned with configured AMQP nodes.
- Add regression coverage for reconnect, broker health, and payload serialization edge cases.

## Testing
- `npm run lint` passed.
- `npm test` passed.
- `npm run test:cov` passed with improved coverage across `src/Amqp.ts` and the node handlers.