### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/frankvdb7/node-red-contrib-amqp/security/code-scanning/3](https://github.com/frankvdb7/node-red-contrib-amqp/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (near `name`/`on`) since there is only one job and no step needs write scopes. Use:

- `contents: read`

This preserves current functionality (checkout and npm commands) while preventing unintended write capabilities.

Change location: `.github/workflows/nodejs.yml`, directly after the `on` section (or before `jobs`), adding a top-level `permissions` key.

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
