### PR TITLE
Improve RabbitMQ reconnect handling and acknowledgment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The nodes support runtime control via `msg`:
 - `amqp-in-manual-ack`
   - `msg.manualAck.ackMode`: explicit ack mode (`ack`, `ackAll`, `nack`, `nackAll`, `reject`).
   - `msg.manualAck.requeue`: used by `nack`, `nackAll`, and `reject` (defaults to `true`).
-  - The node keeps the original AMQP message mapped by `deliveryTag`, so manual acknowledgment can operate correctly after flow processing.
+  - The node keeps the original AMQP delivery behind an internal token so acknowledgments can survive normal Node-RED message cloning. Tokens are tied to the channel that delivered the message; acknowledgments from before a reconnect are rejected locally.
 
 ### Examples
 

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -1506,7 +1506,7 @@ export default class Amqp {
     }
 
     const entry = Amqp.connectionPool.get(key)
-    if (entry?.connection === this.connection) {
+    if (entry && this.connection && entry.connection === this.connection) {
       entry.count -= 1
       if (entry.count <= 0) {
         Amqp.connectionPool.delete(key)

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -8,7 +8,7 @@ import {
   Replies,
   connect,
   ConsumeMessage,
-  MessageProperties,
+  Options,
 } from 'amqplib'
 import {
   AmqpConfig,
@@ -27,6 +27,40 @@ import {
 } from './types'
 import { NODE_STATUS } from './constants'
 
+const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
+const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
+
+type TrackedAssembledMessage = AssembledMessage & {
+  [DELIVERY_TOKEN]?: string
+}
+
+interface TrackedDelivery {
+  message: AssembledMessage
+  channel: Channel
+  deliveryTag: number
+}
+
+interface PendingRpcRequest {
+  owner: Amqp
+  handleResponse: (message: AssembledMessage) => void
+  recordUnexpectedCorrelation: (correlationId: unknown) => void
+  interrupt: (error: Error, cleanup: boolean) => void
+  cancel: () => void
+}
+
+interface RpcConsumerState {
+  key: string
+  channel: Channel
+  queueName: string
+  consumerTag: string
+  pending: Map<string, PendingRpcRequest>
+  ready: Promise<void>
+  cleanupPromise: Promise<void> | null
+  cleanedUp: boolean
+  registry: Map<string, RpcConsumerState>
+  users: Set<Amqp>
+}
+
 export default class Amqp {
   private config: AmqpConfig
   private broker: AmqpBrokerNode
@@ -35,12 +69,21 @@ export default class Amqp {
   private q: Replies.AssertQueue
   private vhostOverride?: string
   private static connectionPool: Map<string, { connection: ChannelModel; count: number }> = new Map()
+  private static pendingConnections: Map<string, Promise<ChannelModel>> = new Map()
+  private static rpcConsumerRegistries: WeakMap<
+    object,
+    Map<string, RpcConsumerState>
+  > = new WeakMap()
   private connectionErrorHandler: (e: unknown) => void
   private connectionCloseHandler: () => void
   private channelErrorHandler: (e: unknown) => void
   private channelCloseHandler: () => void
-  private channelReturnHandler: () => void
+  private channelReturnHandler: (message: ConsumeMessage) => void
   private rpcTimeouts: Set<NodeJS.Timeout> = new Set()
+  private rpcInterruptHandlers: Set<(error: Error) => void> = new Set()
+  private rpcConsumers: Map<string, RpcConsumerState> = new Map()
+  private returnedPublishes: Map<string, Error> = new Map()
+  private trackedDeliveries: Map<string, TrackedDelivery> = new Map()
   private closed = false
 
   constructor(
@@ -73,7 +116,7 @@ export default class Amqp {
       },
       amqpProperties: this.parseJsonObject(
         config.amqpProperties,
-      ) as unknown as MessageProperties,
+      ) as unknown as Options.Publish,
       headers: this.parseJsonObject(config.headers),
       outputs: config.outputs,
       rpcTimeout: config.rpcTimeoutMilliseconds,
@@ -113,24 +156,31 @@ export default class Amqp {
     }
 
     if (!entry) {
-      this.node.log(`Connecting to AMQP broker ${brokerInfo}`)
+      let pendingConnection = Amqp.pendingConnections.get(key)
+      if (!pendingConnection) {
+        this.node.log(`Connecting to AMQP broker ${brokerInfo}`)
+        pendingConnection = this.createPooledConnection(
+          key,
+          brokerUrl,
+          brokerInfo,
+        )
+        Amqp.pendingConnections.set(key, pendingConnection)
+      }
+
       try {
-        const connection = await connect(brokerUrl, { heartbeat: 2 })
-        this.node.log(`Connected to AMQP broker ${brokerInfo}`)
-
-        connection.on('close', () => {
-          const current = Amqp.connectionPool.get(key)
-          if (current?.connection === connection) {
-            Amqp.connectionPool.delete(key)
-          }
-        })
-
-        entry = { connection, count: 0 }
-        Amqp.connectionPool.set(key, entry)
+        const connection = await pendingConnection
+        entry = Amqp.connectionPool.get(key)
+        if (!entry || entry.connection !== connection) {
+          throw new Error(`AMQP connection closed while connecting to ${brokerInfo}`)
+        }
       } catch (err) {
         this.setBrokerNodeState('errored', err)
         this.node.warn(`Failed to connect to AMQP broker ${brokerInfo}: ${err}`)
         throw err
+      } finally {
+        if (Amqp.pendingConnections.get(key) === pendingConnection) {
+          Amqp.pendingConnections.delete(key)
+        }
       }
     }
 
@@ -239,7 +289,7 @@ export default class Amqp {
     }
 
     try {
-      await this.close()
+      await this.close(new Error('AMQP virtual host changed during RPC'))
       this.vhostOverride = newVhost
       await this.connect()
       await this.initialize()
@@ -258,76 +308,142 @@ export default class Amqp {
     return this.channel
   }
 
-  public ack(msg: AssembledMessage): void {
+  public ack(msg: AssembledMessage): boolean {
     const allUpTo = !!msg.manualAck?.allUpTo
+    const delivery = this.resolveDelivery(msg, 'ack')
+    if (!delivery) {
+      return false
+    }
     try {
-      this.node.log(`Acking message with deliveryTag: ${msg?.fields?.deliveryTag}`)
-      this.channel.ack(msg, allUpTo)
+      this.node.log(
+        `Acking message with deliveryTag: ${delivery.message.fields?.deliveryTag}`,
+      )
+      this.channel.ack(delivery.message, allUpTo)
+      this.removeTrackedDeliveries(delivery, allUpTo)
+      return true
     } catch (e) {
       this.node.error(`Could not ack message: ${e}`)
+      return false
     }
   }
 
-  public ackAll(): void {
+  public ackAll(msg?: AssembledMessage): boolean {
+    if (this.isManualAck() && (!msg || !this.resolveDelivery(msg, 'ackAll'))) {
+      return false
+    }
     try {
       this.node.log('Acking all outstanding messages')
       this.channel.ackAll()
+      this.trackedDeliveries.clear()
+      return true
     } catch (e) {
       this.node.error(`Could not ackAll messages: ${e}`)
+      return false
     }
   }
 
-  public nack(msg: AssembledMessage): void {
+  public nack(msg: AssembledMessage): boolean {
     const allUpTo = !!msg.manualAck?.allUpTo
     const requeue = msg.manualAck?.requeue ?? true
+    const delivery = this.resolveDelivery(msg, 'nack')
+    if (!delivery) {
+      return false
+    }
     try {
       this.node.log(
-        `Nacking message with deliveryTag: ${msg?.fields?.deliveryTag}`,
+        `Nacking message with deliveryTag: ${delivery.message.fields?.deliveryTag}`,
       )
-      this.channel.nack(msg, allUpTo, requeue)
+      this.channel.nack(delivery.message, allUpTo, requeue)
+      this.removeTrackedDeliveries(delivery, allUpTo)
+      return true
     } catch (e) {
       this.node.error(`Could not nack message: ${e}`)
+      return false
     }
   }
 
-  public nackAll(msg: AssembledMessage): void {
+  public nackAll(msg: AssembledMessage): boolean {
     const requeue = msg.manualAck?.requeue ?? true
+    if (!this.resolveDelivery(msg, 'nackAll')) {
+      return false
+    }
     try {
       this.node.log('Nacking all outstanding messages')
       this.channel.nackAll(requeue)
+      this.trackedDeliveries.clear()
+      return true
     } catch (e) {
       this.node.error(`Could not nackAll messages: ${e}`)
+      return false
     }
   }
 
-  public reject(msg: AssembledMessage): void {
+  public reject(msg: AssembledMessage): boolean {
     const requeue = msg.manualAck?.requeue ?? true
+    const delivery = this.resolveDelivery(msg, 'reject')
+    if (!delivery) {
+      return false
+    }
     try {
       this.node.log(
-        `Rejecting message with deliveryTag: ${msg?.fields?.deliveryTag}`,
+        `Rejecting message with deliveryTag: ${delivery.message.fields?.deliveryTag}`,
       )
-      this.channel.reject(msg, requeue)
+      this.channel.reject(delivery.message, requeue)
+      this.removeTrackedDeliveries(delivery, false)
+      return true
     } catch (e) {
       this.node.error(`Could not reject message: ${e}`)
+      return false
     }
   }
 
   public async publish(
     msg: unknown,
-    properties?: MessageProperties,
+    properties?: Options.Publish,
   ): Promise<void> {
     const routingKeys = this.parseRoutingKeys()
-    await Promise.all(
+    const results = await Promise.allSettled(
       routingKeys.map(routingKey =>
         this.handlePublish(this.config, msg, properties, routingKey),
       ),
     )
+    const failedRoutingKeys = routingKeys.filter(
+      (_, index) => results[index].status === 'rejected',
+    )
+    if (failedRoutingKeys.length === 0) {
+      return
+    }
+
+    if (routingKeys.length === 1) {
+      throw (results[0] as PromiseRejectedResult).reason
+    }
+
+    const successfulRoutingKeys = routingKeys.filter(
+      (_, index) => results[index].status === 'fulfilled',
+    )
+    const error = new Error(
+      `AMQP publish failed for routing keys: ${failedRoutingKeys.join(', ')}`,
+    ) as Error & {
+      successfulRoutingKeys: string[]
+      failedRoutingKeys: string[]
+      causes: unknown[]
+    }
+    error.name = 'AmqpPartialPublishError'
+    error.successfulRoutingKeys = successfulRoutingKeys
+    error.failedRoutingKeys = failedRoutingKeys
+    error.causes = results
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      .map(result => result.reason)
+    throw error
   }
 
   private async handlePublish(
     config: AmqpConfig,
     msg: unknown,
-    properties?: MessageProperties,
+    properties?: Options.Publish,
     routingKey?: string,
   ) {
     const {
@@ -336,6 +452,7 @@ export default class Amqp {
     } = config
 
     let cancelRpcConsumer: (() => Promise<void>) | null = null
+    let returnToken: string | undefined
 
     try {
       let correlationId = ''
@@ -361,19 +478,45 @@ export default class Amqp {
         ...this.config.amqpProperties,
         ...properties,
       }
+      const mandatory = options.mandatory
+      if (mandatory) {
+        if (!config.waitForConfirms) {
+          throw new Error(
+            'Mandatory publishing requires publisher confirmations',
+          )
+        }
+        returnToken = uuidv4()
+        options.headers = {
+          ...options.headers,
+          [RETURN_TOKEN_HEADER]: returnToken,
+        }
+      }
       // when the name field is empty, publish just like the sendToQueue method;
       // see https://amqp-node.github.io/amqplib/channel_api.html#channel_publish
-      this.channel.publish(
+      const accepted = this.channel.publish(
         name,
         routingKey,
         this.toPublishBuffer(msg),
         options,
       )
+      if (accepted === false) {
+        await this.waitForChannelDrain(this.channel)
+      }
 
       if (config.waitForConfirms) {
         await (this.channel as ConfirmChannel).waitForConfirms()
       }
+      if (returnToken) {
+        const returnedError = this.returnedPublishes.get(returnToken)
+        this.returnedPublishes.delete(returnToken)
+        if (returnedError) {
+          throw returnedError
+        }
+      }
     } catch (e) {
+      if (returnToken) {
+        this.returnedPublishes.delete(returnToken)
+      }
       if (cancelRpcConsumer) {
         await cancelRpcConsumer()
       }
@@ -399,17 +542,19 @@ export default class Amqp {
     replyTo: string,
   ): Promise<() => Promise<void>> {
     const rpcConfig = this.getRpcConfig(replyTo)
-    let queueName = ''
 
     try {
-      // If we try to delete a queue that's already deleted
-      // bad things will happen.
-      let rpcQueueHasBeenDeleted = false
+      const rpcConsumer = await this.getOrCreateRpcConsumer(replyTo, rpcConfig)
+      if (rpcConsumer.pending.has(correlationId)) {
+        throw new Error(
+          `RPC correlation ID is already in use: ${correlationId}`,
+        )
+      }
+
       let rpcResponseFinalized = false
       let additionalErrorMessaging = ''
       let rpcTimeout: NodeJS.Timeout | null = null
-      let rpcConsumerTag = ''
-      let cleanupPromise: Promise<void> | null = null
+      let interruptRpc: ((error: Error) => void) | null = null
 
       const clearRpcTimeout = (): void => {
         if (rpcTimeout) {
@@ -424,39 +569,20 @@ export default class Amqp {
           return false
         }
         rpcResponseFinalized = true
+        if (interruptRpc) {
+          this.rpcInterruptHandlers.delete(interruptRpc)
+        }
+        if (rpcConsumer.pending.get(correlationId) === pendingRequest) {
+          rpcConsumer.pending.delete(correlationId)
+        }
         clearRpcTimeout()
         return true
       }
 
       const cleanupRpcResources = async (): Promise<void> => {
-        if (rpcQueueHasBeenDeleted || !queueName) {
-          return
+        if (rpcConsumer.pending.size === 0) {
+          await this.cleanupRpcConsumer(rpcConsumer)
         }
-
-        if (!cleanupPromise) {
-          cleanupPromise = (async () => {
-            try {
-              await this.channel.deleteQueue(queueName)
-              rpcQueueHasBeenDeleted = true
-            } catch (deleteError) {
-              this.node.error(`Error trying to cancel RPC consumer: ${deleteError}`)
-
-              const canCancelConsumer = typeof this.channel.cancel === 'function'
-              if (canCancelConsumer && rpcConsumerTag) {
-                try {
-                  await this.channel.cancel(rpcConsumerTag)
-                  rpcQueueHasBeenDeleted = true
-                } catch (cancelError) {
-                  this.node.error(`Error trying to cancel RPC consumer: ${cancelError}`)
-                }
-              }
-            } finally {
-              cleanupPromise = null
-            }
-          })()
-        }
-
-        await cleanupPromise
       }
 
       const cancelRpcConsumer = async (): Promise<void> => {
@@ -464,29 +590,37 @@ export default class Amqp {
         await cleanupRpcResources()
       }
 
-      /************************************
-       * assert queue and set up consumer
-       ************************************/
-      queueName = await this.assertQueue(rpcConfig)
-
-      const consumeResponse = await this.channel.consume(
-        queueName,
-        amqpMessage => {
-          if (amqpMessage) {
-            const msg = this.assembleMessage(amqpMessage)
-            if (msg.properties.correlationId === correlationId) {
-              if (finalizeRpcResponse()) {
-                this.node.send(msg as any)
-                void cleanupRpcResources()
-              }
-            } else {
-              additionalErrorMessaging += ` Correlation ids do not match. Expecting: ${correlationId}, received: ${msg.properties.correlationId}`
+      const pendingRequest: PendingRpcRequest = {
+        owner: this,
+        handleResponse: msg => {
+          if (finalizeRpcResponse()) {
+            this.node.send(msg as any)
+            void cleanupRpcResources()
+          }
+        },
+        recordUnexpectedCorrelation: receivedCorrelationId => {
+          additionalErrorMessaging += ` Correlation ids do not match. Expecting: ${correlationId}, received: ${receivedCorrelationId}`
+        },
+        interrupt: (error, cleanup) => {
+          if (finalizeRpcResponse()) {
+            this.node.send({
+              payload: {
+                message: `RPC interrupted: ${error.message}`,
+                config: rpcConfig,
+              },
+            })
+            if (cleanup) {
+              void cleanupRpcResources()
             }
           }
         },
-        { noAck: rpcConfig.noAck },
-      )
-      rpcConsumerTag = consumeResponse?.consumerTag || ''
+        cancel: () => {
+          finalizeRpcResponse()
+        },
+      }
+      rpcConsumer.pending.set(correlationId, pendingRequest)
+      interruptRpc = error => pendingRequest.interrupt(error, false)
+      this.rpcInterruptHandlers.add(interruptRpc)
 
       /****************************************
        * Check if RPC has timed out and handle
@@ -516,22 +650,213 @@ export default class Amqp {
       this.rpcTimeouts.add(rpcTimeout)
       return cancelRpcConsumer
     } catch (e) {
-      // If setup failed after queue assertion, try to clean up the temporary RPC queue.
-      if (queueName) {
-        await this.channel.deleteQueue(queueName).catch(deleteError => {
-          this.node.error(`Error trying to cancel RPC consumer: ${deleteError}`)
-        })
-      }
       this.node.error(`Could not consume RPC message: ${e}`)
       throw e
     }
   }
 
-  public async close(): Promise<void> {
+  private async getOrCreateRpcConsumer(
+    replyTo: string,
+    rpcConfig: AmqpConfig,
+  ): Promise<RpcConsumerState> {
+    const registry = this.getRpcConsumerRegistry()
+    const existing = registry.get(replyTo)
+    if (existing && !existing.cleanedUp) {
+      existing.users.add(this)
+      this.rpcConsumers.set(replyTo, existing)
+      await existing.ready
+      return existing
+    }
+
+    const state: RpcConsumerState = {
+      key: replyTo,
+      channel: this.channel,
+      queueName: '',
+      consumerTag: '',
+      pending: new Map(),
+      ready: Promise.resolve(),
+      cleanupPromise: null,
+      cleanedUp: false,
+      registry,
+      users: new Set([this]),
+    }
+
+    registry.set(replyTo, state)
+    this.rpcConsumers.set(replyTo, state)
+    state.ready = (async () => {
+      try {
+        state.queueName = await this.assertQueue(rpcConfig)
+        const consumeResponse = await state.channel.consume(
+          state.queueName,
+          amqpMessage => {
+            if (!amqpMessage) {
+              const error = new Error('AMQP RPC consumer was cancelled')
+              for (const request of [...state.pending.values()]) {
+                request.interrupt(error, true)
+              }
+              return
+            }
+
+            const msg = this.assembleMessage(amqpMessage)
+            const receivedCorrelationId = msg.properties.correlationId
+            const request =
+              typeof receivedCorrelationId === 'string'
+                ? state.pending.get(receivedCorrelationId)
+                : undefined
+            if (request) {
+              request.handleResponse(msg)
+              return
+            }
+
+            for (const pendingRequest of state.pending.values()) {
+              pendingRequest.recordUnexpectedCorrelation(receivedCorrelationId)
+            }
+          },
+          { noAck: rpcConfig.noAck },
+        )
+        state.consumerTag = consumeResponse?.consumerTag || ''
+      } catch (error) {
+        await this.cleanupRpcConsumer(state)
+        throw error
+      }
+    })()
+
+    await state.ready
+    return state
+  }
+
+  private getRpcConsumerRegistry(): Map<string, RpcConsumerState> {
+    const scope = (this.connection || this.channel) as unknown as object
+    let registry = Amqp.rpcConsumerRegistries.get(scope)
+    if (!registry) {
+      registry = new Map()
+      Amqp.rpcConsumerRegistries.set(scope, registry)
+    }
+    return registry
+  }
+
+  private async cleanupRpcConsumer(state: RpcConsumerState): Promise<void> {
+    if (state.cleanupPromise) {
+      await state.cleanupPromise
+      return
+    }
+    if (state.cleanedUp) {
+      return
+    }
+
+    state.cleanedUp = true
+    if (state.registry.get(state.key) === state) {
+      state.registry.delete(state.key)
+    }
+    for (const user of state.users) {
+      if (user.rpcConsumers.get(state.key) === state) {
+        user.rpcConsumers.delete(state.key)
+      }
+    }
+    state.users.clear()
+
+    state.cleanupPromise = (async () => {
+      if (!state.queueName) {
+        return
+      }
+
+      try {
+        await state.channel.deleteQueue(state.queueName)
+      } catch (deleteError) {
+        this.node.error(`Error trying to cancel RPC consumer: ${deleteError}`)
+
+        const canCancelConsumer = typeof state.channel.cancel === 'function'
+        if (canCancelConsumer && state.consumerTag) {
+          try {
+            await state.channel.cancel(state.consumerTag)
+          } catch (cancelError) {
+            this.node.error(`Error trying to cancel RPC consumer: ${cancelError}`)
+          }
+        }
+      }
+    })()
+
+    await state.cleanupPromise
+  }
+
+  private async detachRpcConsumers(interruption?: Error): Promise<void> {
+    const states = [...new Set(this.rpcConsumers.values())]
+    for (const state of states) {
+      for (const request of [...state.pending.values()]) {
+        if (request.owner === this) {
+          request.cancel()
+        }
+      }
+
+      state.users.delete(this)
+      if (this.rpcConsumers.get(state.key) === state) {
+        this.rpcConsumers.delete(state.key)
+      }
+
+      if (state.channel === this.channel) {
+        const error =
+          interruption ?? new Error('Shared AMQP RPC consumer was closed')
+        for (const request of [...state.pending.values()]) {
+          request.interrupt(error, false)
+        }
+        state.pending.clear()
+        state.cleanedUp = true
+        if (state.registry.get(state.key) === state) {
+          state.registry.delete(state.key)
+        }
+        for (const user of state.users) {
+          if (user.rpcConsumers.get(state.key) === state) {
+            user.rpcConsumers.delete(state.key)
+          }
+        }
+        state.users.clear()
+      } else if (state.pending.size === 0) {
+        await this.cleanupRpcConsumer(state)
+      }
+    }
+  }
+
+  private waitForChannelDrain(channel: Channel): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const cleanup = (): void => {
+        channel.off('drain', onDrain)
+        channel.off('close', onClose)
+        channel.off('error', onError)
+      }
+      const onDrain = (): void => {
+        cleanup()
+        resolve()
+      }
+      const onClose = (): void => {
+        cleanup()
+        reject(new Error('AMQP channel closed while waiting for write buffer'))
+      }
+      const onError = (error: unknown): void => {
+        cleanup()
+        reject(
+          error instanceof Error
+            ? error
+            : new Error(`AMQP channel error: ${String(error)}`),
+        )
+      }
+
+      channel.once('drain', onDrain)
+      channel.once('close', onClose)
+      channel.once('error', onError)
+    })
+  }
+
+  public async close(interruption?: Error): Promise<void> {
     if (this.closed) {
       return
     }
     this.closed = true
+    if (interruption) {
+      for (const interruptRpc of [...this.rpcInterruptHandlers]) {
+        interruptRpc(interruption)
+      }
+    }
+    await this.detachRpcConsumers(interruption)
     this.clearRpcTimeouts()
 
     await this.unbindQueues()
@@ -573,6 +898,9 @@ export default class Amqp {
   }
 
   private async closeChannel(): Promise<void> {
+    this.trackedDeliveries.clear()
+    this.returnedPublishes.clear()
+    this.rpcInterruptHandlers.clear()
     if (this.channel) {
       this.channel.off?.('error', this.channelErrorHandler)
       this.channel.off?.('close', this.channelCloseHandler)
@@ -600,7 +928,7 @@ export default class Amqp {
     }
 
     const entry = Amqp.connectionPool.get(key)
-    if (entry) {
+    if (entry?.connection === this.connection) {
       entry.count -= 1
       if (entry.count <= 0) {
         Amqp.connectionPool.delete(key)
@@ -614,9 +942,30 @@ export default class Amqp {
     }
   }
 
+  private async createPooledConnection(
+    key: string,
+    brokerUrl: string,
+    brokerInfo: string,
+  ): Promise<ChannelModel> {
+    const connection = await connect(brokerUrl, { heartbeat: 2 })
+    this.node.log(`Connected to AMQP broker ${brokerInfo}`)
+
+    const entry = { connection, count: 0 }
+    Amqp.connectionPool.set(key, entry)
+    connection.on('close', () => {
+      const current = Amqp.connectionPool.get(key)
+      if (current?.connection === connection) {
+        Amqp.connectionPool.delete(key)
+      }
+    })
+
+    return connection
+  }
+
   private async createChannel(): Promise<Channel> {
     const { prefetch, waitForConfirms } = this.config
 
+    this.trackedDeliveries.clear()
     this.channel = await (waitForConfirms
       ? this.connection.createConfirmChannel()
       : this.connection.createChannel())
@@ -635,9 +984,21 @@ export default class Amqp {
       this.node.log('AMQP Channel closed')
     }
 
-    this.channelReturnHandler = (): void => {
+    this.channelReturnHandler = (message): void => {
       /* istanbul ignore next */
-      this.node.warn('AMQP Message returned')
+      const returnToken = message.properties.headers?.[RETURN_TOKEN_HEADER]
+      const { replyCode, replyText, exchange, routingKey } = message.fields as
+        typeof message.fields & {
+          replyCode: number
+          replyText: string
+        }
+      const returnedError = new Error(
+        `AMQP Message returned (${replyCode} ${replyText}) from ${exchange} with routing key ${routingKey}`,
+      )
+      if (typeof returnToken === 'string') {
+        this.returnedPublishes.set(returnToken, returnedError)
+      }
+      this.node.warn(returnedError.message)
     }
 
     this.channel.on('error', this.channelErrorHandler)
@@ -756,12 +1117,71 @@ export default class Amqp {
 
   private assembleMessage(amqpMessage: ConsumeMessage): AssembledMessage {
     const payload = this.parseJson(amqpMessage.content.toString(), true)
-    ;(amqpMessage as AssembledMessage).payload = payload
-    return amqpMessage as AssembledMessage
+    const msg = amqpMessage as TrackedAssembledMessage
+    msg.payload = payload
+    if (this.isManualAck()) {
+      const token = uuidv4()
+      msg[DELIVERY_TOKEN] = token
+      this.trackedDeliveries.set(token, {
+        message: msg,
+        channel: this.channel,
+        deliveryTag: msg.fields.deliveryTag,
+      })
+    }
+    return msg
   }
 
   private isManualAck(): boolean {
     return this.node.type === NodeType.AmqpInManualAck
+  }
+
+  private resolveDelivery(
+    msg: AssembledMessage,
+    operation: string,
+  ): (TrackedDelivery & { token?: string }) | null {
+    if (!this.isManualAck()) {
+      return {
+        message: msg,
+        channel: this.channel,
+        deliveryTag: msg.fields?.deliveryTag ?? 0,
+      }
+    }
+
+    const token = (msg as TrackedAssembledMessage)[DELIVERY_TOKEN]
+    const delivery = token ? this.trackedDeliveries.get(token) : undefined
+    if (!delivery || delivery.channel !== this.channel) {
+      this.node.error(
+        `Could not ${operation} message: delivery does not belong to the active AMQP channel`,
+      )
+      return null
+    }
+
+    return { ...delivery, token }
+  }
+
+  private removeTrackedDeliveries(
+    delivery: TrackedDelivery & { token?: string },
+    allUpTo: boolean,
+  ): void {
+    if (!this.isManualAck()) {
+      return
+    }
+
+    if (!allUpTo) {
+      if (delivery.token) {
+        this.trackedDeliveries.delete(delivery.token)
+      }
+      return
+    }
+
+    for (const [token, trackedDelivery] of this.trackedDeliveries) {
+      if (
+        trackedDelivery.channel === delivery.channel &&
+        trackedDelivery.deliveryTag <= delivery.deliveryTag
+      ) {
+        this.trackedDeliveries.delete(token)
+      }
+    }
   }
 
   private parseJson(jsonInput: unknown, logError = false): JsonValue {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -77,6 +77,7 @@ interface AmqpCloseOptions {
 
 interface AmqpConnectOptions {
   timeout?: number
+  signal?: AbortSignal
 }
 
 interface PendingConnection {
@@ -245,10 +246,14 @@ export default class Amqp {
 
       pendingConnection.activeWaiters += 1
       try {
-        const connection = await this.awaitConnection(
-          pendingConnection.promise,
-          brokerInfo,
-          options.timeout,
+        const connection = await this.awaitAbortable(
+          this.awaitConnection(
+            pendingConnection.promise,
+            brokerInfo,
+            options.timeout,
+          ),
+          options.signal,
+          'AMQP connection attempt was cancelled',
         )
         entry = Amqp.connectionPool.get(key)
         if (!entry) {
@@ -326,12 +331,21 @@ export default class Amqp {
     }
   }
 
-  public async initialize(): Promise<Channel> {
-    await this.createChannel()
-    if (this.shouldAutoCreateExchangeBindings()) {
-      await this.assertExchange()
-    }
-    return this.channel;
+  public async initialize(
+    options: Pick<AmqpConnectOptions, 'signal'> = {},
+  ): Promise<Channel> {
+    const initialization = (async (): Promise<Channel> => {
+      await this.createChannel()
+      if (this.shouldAutoCreateExchangeBindings()) {
+        await this.assertExchange()
+      }
+      return this.channel
+    })()
+    return this.awaitAbortable(
+      initialization,
+      options.signal,
+      'AMQP channel initialization was cancelled',
+    )
   }
 
   public async consume(): Promise<void> {
@@ -1576,6 +1590,42 @@ export default class Amqp {
     } finally {
       if (timeoutHandle) {
         clearTimeout(timeoutHandle)
+      }
+    }
+  }
+
+  private async awaitAbortable<T>(
+    operation: Promise<T>,
+    signal: AbortSignal | undefined,
+    fallbackMessage: string,
+  ): Promise<T> {
+    if (!signal) {
+      return operation
+    }
+    if (signal.aborted) {
+      throw signal.reason instanceof Error
+        ? signal.reason
+        : new Error(fallbackMessage)
+    }
+
+    let abortHandler: (() => void) | undefined
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          abortHandler = () => {
+            reject(
+              signal.reason instanceof Error
+                ? signal.reason
+                : new Error(fallbackMessage),
+            )
+          }
+          signal.addEventListener('abort', abortHandler, { once: true })
+        }),
+      ])
+    } finally {
+      if (abortHandler) {
+        signal.removeEventListener('abort', abortHandler)
       }
     }
   }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -661,7 +661,16 @@ export default class Amqp {
   ): Promise<RpcConsumerState> {
     const registry = this.getRpcConsumerRegistry()
     const existing = registry.get(replyTo)
-    if (existing && !existing.cleanedUp) {
+    if (existing?.cleanedUp) {
+      if (existing.cleanupPromise) {
+        await existing.cleanupPromise
+      }
+      if (registry.get(replyTo) === existing) {
+        registry.delete(replyTo)
+      }
+      return this.getOrCreateRpcConsumer(replyTo, rpcConfig)
+    }
+    if (existing) {
       existing.users.add(this)
       this.rpcConsumers.set(replyTo, existing)
       await existing.ready
@@ -745,9 +754,6 @@ export default class Amqp {
     }
 
     state.cleanedUp = true
-    if (state.registry.get(state.key) === state) {
-      state.registry.delete(state.key)
-    }
     for (const user of state.users) {
       if (user.rpcConsumers.get(state.key) === state) {
         user.rpcConsumers.delete(state.key)
@@ -776,7 +782,13 @@ export default class Amqp {
       }
     })()
 
-    await state.cleanupPromise
+    try {
+      await state.cleanupPromise
+    } finally {
+      if (state.registry.get(state.key) === state) {
+        state.registry.delete(state.key)
+      }
+    }
   }
 
   private async detachRpcConsumers(interruption?: Error): Promise<void> {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -201,13 +201,28 @@ export default class Amqp {
           key,
           brokerUrl,
           brokerInfo,
-          options.timeout,
         )
         Amqp.pendingConnections.set(key, pendingConnection)
+        void pendingConnection.then(
+          () => {
+            if (Amqp.pendingConnections.get(key) === pendingConnection) {
+              Amqp.pendingConnections.delete(key)
+            }
+          },
+          () => {
+            if (Amqp.pendingConnections.get(key) === pendingConnection) {
+              Amqp.pendingConnections.delete(key)
+            }
+          },
+        )
       }
 
       try {
-        const connection = await pendingConnection
+        const connection = await this.awaitConnection(
+          pendingConnection,
+          brokerInfo,
+          options.timeout,
+        )
         entry = Amqp.connectionPool.get(key)
         if (!entry || entry.connection !== connection) {
           throw new Error(`AMQP connection closed while connecting to ${brokerInfo}`)
@@ -216,10 +231,6 @@ export default class Amqp {
         this.setBrokerNodeState('errored', err)
         this.node.warn(`Failed to connect to AMQP broker ${brokerInfo}: ${err}`)
         throw err
-      } finally {
-        if (Amqp.pendingConnections.get(key) === pendingConnection) {
-          Amqp.pendingConnections.delete(key)
-        }
       }
     }
 
@@ -1185,16 +1196,20 @@ export default class Amqp {
     }
 
     const cleanupOperation = (async (): Promise<void> => {
+      let lastError: unknown
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         let connected = false
         try {
           await this.connect({ timeout: AMQP_CONNECTION_TIMEOUT_MS })
           connected = true
-          await this.initialize()
+          await this.createChannel()
           if (await this.unbindQueues(true)) {
             this.bindingsRemoved = true
             return
           }
+          lastError = new Error('One or more AMQP queue bindings could not be removed')
+        } catch (error) {
+          lastError = error
         } finally {
           if (connected) {
             this.closed = true
@@ -1207,9 +1222,11 @@ export default class Amqp {
           }
         }
       }
-      throw new Error(
+      const cleanupError = new Error(
         `Could not remove AMQP bindings after ${BINDING_CLEANUP_MAX_ATTEMPTS} attempts`,
       )
+      ;(cleanupError as Error & { cause?: unknown }).cause = lastError
+      throw cleanupError
     })()
     this.bindingCleanupPromise = cleanupOperation
     try {
@@ -1236,6 +1253,9 @@ export default class Amqp {
         try {
           await this.channel.unbindQueue(queueName, exchangeName, routingKey)
         } catch (e) {
+          if (this.isNotFoundError(e)) {
+            return true
+          }
           succeeded = false
           /* istanbul ignore next */
           this.node.error(`Error unbinding queue for routing key ${routingKey}: ${e.message}`)
@@ -1243,6 +1263,22 @@ export default class Amqp {
       }
     }
     return succeeded
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false
+    }
+    const amqpError = error as {
+      code?: number
+      replyCode?: number
+      message?: string
+    }
+    return (
+      amqpError.code === 404 ||
+      amqpError.replyCode === 404 ||
+      /(?:404|NOT[_-]FOUND)/i.test(amqpError.message ?? '')
+    )
   }
 
   private shouldUnbindQueueOnClose(removeBindings: boolean): boolean {
@@ -1318,15 +1354,8 @@ export default class Amqp {
     key: string,
     brokerUrl: string,
     brokerInfo: string,
-    timeout?: number,
   ): Promise<ChannelModel> {
-    const socketOptions: { heartbeat: number; timeout?: number } = {
-      heartbeat: 2,
-    }
-    if (timeout !== undefined) {
-      socketOptions.timeout = timeout
-    }
-    const connection = await connect(brokerUrl, socketOptions)
+    const connection = await connect(brokerUrl, { heartbeat: 2 })
     this.node.log(`Connected to AMQP broker ${brokerInfo}`)
 
     const entry = { connection, count: 0 }
@@ -1339,6 +1368,38 @@ export default class Amqp {
     })
 
     return connection
+  }
+
+  private async awaitConnection(
+    pendingConnection: Promise<ChannelModel>,
+    brokerInfo: string,
+    timeout?: number,
+  ): Promise<ChannelModel> {
+    if (timeout === undefined) {
+      return pendingConnection
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined
+    try {
+      return await Promise.race([
+        pendingConnection,
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `AMQP connection to ${brokerInfo} timed out after ${timeout}ms`,
+                ),
+              ),
+            timeout,
+          )
+        }),
+      ])
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
+      }
+    }
   }
 
   private async createChannel(): Promise<Channel> {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -29,6 +29,7 @@ import { NODE_STATUS } from './constants'
 
 const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
+const MAX_UNMATCHED_RPC_RESPONSES = 100
 
 type TrackedAssembledMessage = AssembledMessage & {
   [DELIVERY_TOKEN]?: string
@@ -43,7 +44,6 @@ interface TrackedDelivery {
 interface PendingRpcRequest {
   owner: Amqp
   handleResponse: (message: AssembledMessage) => void
-  recordUnexpectedCorrelation: (correlationId: unknown) => void
   interrupt: (error: Error, cleanup: boolean) => void
   cancel: () => void
 }
@@ -54,6 +54,8 @@ interface RpcConsumerState {
   queueName: string
   consumerTag: string
   pending: Map<string, PendingRpcRequest>
+  unmatchedResponseCount: number
+  unmatchedResponseOverflow: boolean
   ready: Promise<void>
   cleanupPromise: Promise<void> | null
   cleanedUp: boolean
@@ -64,6 +66,17 @@ interface RpcConsumerState {
 interface AmqpCloseOptions {
   interruption?: Error
   removeBindings?: boolean
+}
+
+interface ChannelDrainGate {
+  channel: Channel
+  promise: Promise<void>
+  reject: (error: Error) => void
+}
+
+interface ChannelWriteQueue {
+  channel: Channel
+  tail: Promise<void>
 }
 
 export default class Amqp {
@@ -90,6 +103,12 @@ export default class Amqp {
   private returnedPublishes: Map<string, Error> = new Map()
   private trackedDeliveries: Map<string, TrackedDelivery> = new Map()
   private closed = false
+  private closePromise: Promise<void> | null = null
+  private bindingCleanupPromise: Promise<void> | null = null
+  private bindingsRemoved = false
+  private channelDrainGate: ChannelDrainGate | null = null
+  private channelWriteQueue: ChannelWriteQueue | null = null
+  private channelWriteFailure: { channel: Channel; error: Error } | null = null
   private lifecycleVersion = 0
 
   constructor(
@@ -211,6 +230,7 @@ export default class Amqp {
     this.connection.on('close', this.connectionCloseHandler)
 
     this.closed = false
+    this.bindingsRemoved = false
 
     return this.connection
   }
@@ -496,29 +516,43 @@ export default class Amqp {
       // when the name field is empty, publish just like the sendToQueue method;
       // see https://amqp-node.github.io/amqplib/channel_api.html#channel_publish
       const content = this.toPublishBuffer(msg)
-      let accepted: boolean
-      let confirmation: Promise<void> | null = null
-      if (config.waitForConfirms) {
-        confirmation = new Promise<void>((resolve, reject) => {
-          accepted = (this.channel as ConfirmChannel).publish(
-            name,
-            routingKey,
-            content,
-            options,
-            error => {
-              if (error) {
-                reject(error)
-                return
-              }
-              resolve()
-            },
-          )
-        })
-      } else {
-        accepted = this.channel.publish(name, routingKey, content, options)
-      }
-      const drain =
-        accepted === false ? this.waitForChannelDrain(this.channel) : null
+      const { confirmation, drain } = await this.writeWithBackpressure(
+        publishChannel => {
+          let accepted: boolean
+          let publishConfirmation: Promise<void> | null = null
+          if (config.waitForConfirms) {
+            publishConfirmation = new Promise<void>((resolve, reject) => {
+              accepted = (publishChannel as ConfirmChannel).publish(
+                name,
+                routingKey,
+                content,
+                options,
+                error => {
+                  if (error) {
+                    reject(error)
+                    return
+                  }
+                  resolve()
+                },
+              )
+            })
+          } else {
+            accepted = publishChannel.publish(
+              name,
+              routingKey,
+              content,
+              options,
+            )
+          }
+          return {
+            confirmation: publishConfirmation,
+            drain:
+              accepted === false
+                ? this.getChannelDrainGate(publishChannel)
+                : null,
+          }
+        },
+      )
       if (confirmation && drain) {
         await Promise.all([confirmation, drain])
       } else if (confirmation) {
@@ -572,7 +606,6 @@ export default class Amqp {
       }
 
       let rpcResponseFinalized = false
-      let additionalErrorMessaging = ''
       let rpcTimeout: NodeJS.Timeout | null = null
       let interruptRpc: ((error: Error) => void) | null = null
 
@@ -618,9 +651,6 @@ export default class Amqp {
             void cleanupRpcResources()
           }
         },
-        recordUnexpectedCorrelation: receivedCorrelationId => {
-          additionalErrorMessaging += ` Correlation ids do not match. Expecting: ${correlationId}, received: ${receivedCorrelationId}`
-        },
         interrupt: (error, cleanup) => {
           if (finalizeRpcResponse()) {
             this.node.send({
@@ -653,9 +683,15 @@ export default class Amqp {
 
         try {
           if (finalizeRpcResponse()) {
+            const unmatchedResponseCount =
+              rpcConsumer.unmatchedResponseCount
+            const unmatchedResponseDiagnostic =
+              unmatchedResponseCount > 0
+                ? ` Observed ${unmatchedResponseCount}${rpcConsumer.unmatchedResponseOverflow ? '+' : ''} unmatched RPC response${unmatchedResponseCount === 1 && !rpcConsumer.unmatchedResponseOverflow ? '' : 's'} on the shared reply consumer.`
+                : ''
             this.node.send({
               payload: {
-                message: `Timeout while waiting for RPC response.${additionalErrorMessaging}`,
+                message: `Timeout while waiting for RPC response.${unmatchedResponseDiagnostic}`,
                 config: rpcConfig,
               },
             })
@@ -703,6 +739,8 @@ export default class Amqp {
       queueName: '',
       consumerTag: '',
       pending: new Map(),
+      unmatchedResponseCount: 0,
+      unmatchedResponseOverflow: false,
       ready: Promise.resolve(),
       cleanupPromise: null,
       cleanedUp: false,
@@ -737,8 +775,13 @@ export default class Amqp {
               return
             }
 
-            for (const pendingRequest of state.pending.values()) {
-              pendingRequest.recordUnexpectedCorrelation(receivedCorrelationId)
+            if (
+              state.unmatchedResponseCount <
+              MAX_UNMATCHED_RPC_RESPONSES
+            ) {
+              state.unmatchedResponseCount += 1
+            } else {
+              state.unmatchedResponseOverflow = true
             }
           },
           { noAck: rpcConfig.noAck },
@@ -848,57 +891,216 @@ export default class Amqp {
     }
   }
 
-  private waitForChannelDrain(channel: Channel): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const cleanup = (): void => {
-        channel.off('drain', onDrain)
-        channel.off('close', onClose)
-        channel.off('error', onError)
+  private async waitForWritableChannel(): Promise<Channel> {
+    while (true) {
+      const channel = this.channel
+      const failure = this.channelWriteFailure
+      if (failure?.channel === channel) {
+        throw failure.error
       }
-      const onDrain = (): void => {
-        cleanup()
-        resolve()
+      const gate = this.channelDrainGate
+      if (!gate || gate.channel !== channel) {
+        return channel
       }
-      const onClose = (): void => {
-        cleanup()
-        reject(new Error('AMQP channel closed while waiting for write buffer'))
-      }
-      const onError = (error: unknown): void => {
-        cleanup()
-        reject(
-          error instanceof Error
-            ? error
-            : new Error(`AMQP channel error: ${String(error)}`),
-        )
-      }
+      await gate.promise
+    }
+  }
 
-      channel.once('drain', onDrain)
-      channel.once('close', onClose)
-      channel.once('error', onError)
+  private async writeWithBackpressure<T>(
+    write: (channel: Channel) => T,
+  ): Promise<T> {
+    const initialChannel = this.channel
+    const failure = this.channelWriteFailure
+    if (failure?.channel === initialChannel) {
+      throw failure.error
+    }
+    const gateActive = this.channelDrainGate?.channel === initialChannel
+    const queueActive = this.channelWriteQueue?.channel === initialChannel
+    if (!gateActive && !queueActive) {
+      return write(initialChannel)
+    }
+
+    const release = await this.acquireChannelWrite(initialChannel)
+    try {
+      const channel = await this.waitForWritableChannel()
+      if (this.closed) {
+        throw new Error('AMQP channel closed while waiting for write buffer')
+      }
+      return write(channel)
+    } finally {
+      release()
+    }
+  }
+
+  private async acquireChannelWrite(channel: Channel): Promise<() => void> {
+    const previous =
+      this.channelWriteQueue?.channel === channel
+        ? this.channelWriteQueue.tail
+        : Promise.resolve()
+    let release: () => void = () => undefined
+    const ticket = new Promise<void>(resolve => {
+      release = resolve
     })
+    const queue = {
+      channel,
+      tail: previous.then(() => ticket),
+    }
+    this.channelWriteQueue = queue
+    await previous
+
+    return () => {
+      release()
+      if (this.channelWriteQueue === queue) {
+        this.channelWriteQueue = null
+      }
+    }
+  }
+
+  private getChannelDrainGate(channel: Channel): Promise<void> {
+    const existingGate = this.channelDrainGate
+    if (existingGate?.channel === channel) {
+      return existingGate.promise
+    }
+    existingGate?.reject(
+      new Error('AMQP channel replaced while waiting for write buffer'),
+    )
+
+    let resolveGate: () => void = () => undefined
+    let rejectGate: (error: Error) => void = () => undefined
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveGate = resolve
+      rejectGate = reject
+    })
+    let settled = false
+    const gate: ChannelDrainGate = {
+      channel,
+      promise,
+      reject: error => {
+        this.channelWriteFailure = { channel, error }
+        settle(() => rejectGate(error))
+      },
+    }
+    const cleanup = (): void => {
+      channel.off('drain', onDrain)
+      channel.off('close', onClose)
+      channel.off('error', onError)
+      if (this.channelDrainGate === gate) {
+        this.channelDrainGate = null
+      }
+    }
+    const settle = (complete: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      complete()
+    }
+    const onDrain = (): void => settle(resolveGate)
+    const onClose = (): void =>
+      gate.reject(
+        new Error('AMQP channel closed while waiting for write buffer'),
+      )
+    const onError = (error: unknown): void =>
+      gate.reject(
+        error instanceof Error
+          ? error
+          : new Error(`AMQP channel error: ${String(error)}`),
+      )
+
+    this.channelDrainGate = gate
+    channel.once('drain', onDrain)
+    channel.once('close', onClose)
+    channel.once('error', onError)
+    return promise
   }
 
   public async close(options?: Error | AmqpCloseOptions): Promise<void> {
-    if (this.closed) {
-      return
-    }
     const interruption =
       options instanceof Error ? options : options?.interruption
     const removeBindings =
       !(options instanceof Error) && options?.removeBindings === true
+    if (this.bindingCleanupPromise) {
+      await this.bindingCleanupPromise
+      return
+    }
+    if (this.closed) {
+      await this.closePromise
+      if (removeBindings) {
+        await this.removeBindingsAfterClose()
+      }
+      return
+    }
     this.closed = true
     this.lifecycleVersion += 1
-    if (interruption) {
-      for (const interruptRpc of [...this.rpcInterruptHandlers]) {
-        interruptRpc(interruption)
+    const closeOperation = (async (): Promise<void> => {
+      if (interruption) {
+        for (const interruptRpc of [...this.rpcInterruptHandlers]) {
+          interruptRpc(interruption)
+        }
+      }
+
+      await this.detachRpcConsumers(interruption)
+      this.clearRpcTimeouts()
+
+      await this.unbindQueues(removeBindings)
+      this.bindingsRemoved ||= removeBindings
+      await this.closeChannel()
+      await this.releaseConnection()
+    })()
+    this.closePromise = closeOperation
+    try {
+      await closeOperation
+    } finally {
+      if (this.closePromise === closeOperation) {
+        this.closePromise = null
       }
     }
-    await this.detachRpcConsumers(interruption)
-    this.clearRpcTimeouts()
+  }
 
-    await this.unbindQueues(removeBindings)
-    await this.closeChannel()
-    await this.releaseConnection()
+  private async removeBindingsAfterClose(): Promise<void> {
+    const { name: exchangeName } = this.config.exchange
+    if (
+      this.bindingsRemoved ||
+      !exchangeName ||
+      !this.q?.queue ||
+      !this.shouldUnbindQueueOnClose(true)
+    ) {
+      return
+    }
+    if (this.bindingCleanupPromise) {
+      await this.bindingCleanupPromise
+      return
+    }
+
+    const cleanupOperation = (async (): Promise<void> => {
+      let connected = false
+      try {
+        await this.connect()
+        connected = true
+        await this.initialize()
+        await this.unbindQueues(true)
+        this.bindingsRemoved = true
+      } finally {
+        if (connected) {
+          this.closed = true
+          this.lifecycleVersion += 1
+          try {
+            await this.closeChannel()
+          } finally {
+            await this.releaseConnection()
+          }
+        }
+      }
+    })()
+    this.bindingCleanupPromise = cleanupOperation
+    try {
+      await cleanupOperation
+    } finally {
+      if (this.bindingCleanupPromise === cleanupOperation) {
+        this.bindingCleanupPromise = null
+      }
+    }
   }
 
   private async unbindQueues(removeBindings = false): Promise<void> {
@@ -946,6 +1148,11 @@ export default class Amqp {
     this.returnedPublishes.clear()
     this.rpcInterruptHandlers.clear()
     if (this.channel) {
+      if (this.channelDrainGate?.channel === this.channel) {
+        this.channelDrainGate.reject(
+          new Error('AMQP channel closed while waiting for write buffer'),
+        )
+      }
       this.channel.off?.('error', this.channelErrorHandler)
       this.channel.off?.('close', this.channelCloseHandler)
       this.channel.off?.('return', this.channelReturnHandler)
@@ -1024,6 +1231,7 @@ export default class Amqp {
     }
 
     this.channel = channel
+    this.channelWriteFailure = null
     channel.prefetch(Number(prefetch))
 
     this.channelErrorHandler = (e): void => {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -61,6 +61,11 @@ interface RpcConsumerState {
   users: Set<Amqp>
 }
 
+interface AmqpCloseOptions {
+  interruption?: Error
+  removeBindings?: boolean
+}
+
 export default class Amqp {
   private config: AmqpConfig
   private broker: AmqpBrokerNode
@@ -85,6 +90,7 @@ export default class Amqp {
   private returnedPublishes: Map<string, Error> = new Map()
   private trackedDeliveries: Map<string, TrackedDelivery> = new Map()
   private closed = false
+  private lifecycleVersion = 0
 
   constructor(
     private readonly RED: NodeRedApp,
@@ -400,8 +406,9 @@ export default class Amqp {
   public async publish(
     msg: unknown,
     properties?: Options.Publish,
+    routingKey?: string,
   ): Promise<void> {
-    const routingKeys = this.parseRoutingKeys()
+    const routingKeys = this.parseRoutingKeys(routingKey)
     const results = await Promise.allSettled(
       routingKeys.map(routingKey =>
         this.handlePublish(this.config, msg, properties, routingKey),
@@ -479,12 +486,7 @@ export default class Amqp {
         ...properties,
       }
       const mandatory = options.mandatory
-      if (mandatory) {
-        if (!config.waitForConfirms) {
-          throw new Error(
-            'Mandatory publishing requires publisher confirmations',
-          )
-        }
+      if (mandatory && config.waitForConfirms) {
         returnToken = uuidv4()
         options.headers = {
           ...options.headers,
@@ -493,18 +495,36 @@ export default class Amqp {
       }
       // when the name field is empty, publish just like the sendToQueue method;
       // see https://amqp-node.github.io/amqplib/channel_api.html#channel_publish
-      const accepted = this.channel.publish(
-        name,
-        routingKey,
-        this.toPublishBuffer(msg),
-        options,
-      )
-      if (accepted === false) {
-        await this.waitForChannelDrain(this.channel)
-      }
-
+      const content = this.toPublishBuffer(msg)
+      let accepted: boolean
+      let confirmation: Promise<void> | null = null
       if (config.waitForConfirms) {
-        await (this.channel as ConfirmChannel).waitForConfirms()
+        confirmation = new Promise<void>((resolve, reject) => {
+          accepted = (this.channel as ConfirmChannel).publish(
+            name,
+            routingKey,
+            content,
+            options,
+            error => {
+              if (error) {
+                reject(error)
+                return
+              }
+              resolve()
+            },
+          )
+        })
+      } else {
+        accepted = this.channel.publish(name, routingKey, content, options)
+      }
+      const drain =
+        accepted === false ? this.waitForChannelDrain(this.channel) : null
+      if (confirmation && drain) {
+        await Promise.all([confirmation, drain])
+      } else if (confirmation) {
+        await confirmation
+      } else if (drain) {
+        await drain
       }
       if (returnToken) {
         const returnedError = this.returnedPublishes.get(returnToken)
@@ -858,11 +878,16 @@ export default class Amqp {
     })
   }
 
-  public async close(interruption?: Error): Promise<void> {
+  public async close(options?: Error | AmqpCloseOptions): Promise<void> {
     if (this.closed) {
       return
     }
+    const interruption =
+      options instanceof Error ? options : options?.interruption
+    const removeBindings =
+      !(options instanceof Error) && options?.removeBindings === true
     this.closed = true
+    this.lifecycleVersion += 1
     if (interruption) {
       for (const interruptRpc of [...this.rpcInterruptHandlers]) {
         interruptRpc(interruption)
@@ -871,16 +896,20 @@ export default class Amqp {
     await this.detachRpcConsumers(interruption)
     this.clearRpcTimeouts()
 
-    await this.unbindQueues()
+    await this.unbindQueues(removeBindings)
     await this.closeChannel()
     await this.releaseConnection()
   }
 
-  private async unbindQueues(): Promise<void> {
+  private async unbindQueues(removeBindings = false): Promise<void> {
     const { name: exchangeName } = this.config.exchange
     const queueName = this.q?.queue
 
-    if (exchangeName && queueName && this.shouldUnbindQueueOnClose()) {
+    if (
+      exchangeName &&
+      queueName &&
+      this.shouldUnbindQueueOnClose(removeBindings)
+    ) {
       const routingKeys = this.parseRoutingKeys()
       for (const routingKey of routingKeys) {
         try {
@@ -893,12 +922,15 @@ export default class Amqp {
     }
   }
 
-  private shouldUnbindQueueOnClose(): boolean {
+  private shouldUnbindQueueOnClose(removeBindings: boolean): boolean {
     const { name, exclusive, autoDelete } = this.config.queue
 
     // Keep bindings for long-lived queues so reconnects don't temporarily
     // remove routes and drop unroutable messages in-flight.
-    return this.shouldAutoCreateExchangeBindings() && (!name || exclusive || autoDelete)
+    return (
+      this.shouldAutoCreateExchangeBindings() &&
+      (removeBindings || !name || exclusive || autoDelete)
+    )
   }
 
   private shouldAutoCreateExchangeBindings(configParams?: AmqpConfig): boolean {
@@ -976,12 +1008,23 @@ export default class Amqp {
 
   private async createChannel(): Promise<Channel> {
     const { prefetch, waitForConfirms } = this.config
+    const lifecycleVersion = this.lifecycleVersion
 
     this.trackedDeliveries.clear()
-    this.channel = await (waitForConfirms
+    const channel = await (waitForConfirms
       ? this.connection.createConfirmChannel()
       : this.connection.createChannel())
-    this.channel.prefetch(Number(prefetch))
+    if (this.closed || lifecycleVersion !== this.lifecycleVersion) {
+      try {
+        await channel.close()
+      } catch (error) {
+        this.node.error(`Error closing stale AMQP channel: ${error}`)
+      }
+      throw new Error('AMQP channel creation completed after resources were closed')
+    }
+
+    this.channel = channel
+    channel.prefetch(Number(prefetch))
 
     this.channelErrorHandler = (e): void => {
       /* istanbul ignore next */
@@ -1013,11 +1056,11 @@ export default class Amqp {
       this.node.warn(returnedError.message)
     }
 
-    this.channel.on('error', this.channelErrorHandler)
-    this.channel.on('close', this.channelCloseHandler)
-    this.channel.on('return', this.channelReturnHandler)
+    channel.on('error', this.channelErrorHandler)
+    channel.on('close', this.channelCloseHandler)
+    channel.on('return', this.channelReturnHandler)
 
-    return this.channel;
+    return channel;
   }
 
   private async assertExchange(): Promise<void> {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -30,6 +30,7 @@ import { NODE_STATUS } from './constants'
 const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
+const AMQP_CONNECTION_TIMEOUT_MS = 5_000
 
 type TrackedAssembledMessage = AssembledMessage & {
   [DELIVERY_TOKEN]?: string
@@ -46,6 +47,11 @@ interface PendingRpcRequest {
   handleResponse: (message: AssembledMessage) => void
   interrupt: (error: Error, cleanup: boolean) => void
   cancel: () => void
+}
+
+interface RpcRequestLifecycle {
+  cancel: () => Promise<void>
+  startTimeout: () => void
 }
 
 interface RpcConsumerState {
@@ -478,7 +484,7 @@ export default class Amqp {
       outputs: rpcRequested,
     } = config
 
-    let cancelRpcConsumer: (() => Promise<void>) | null = null
+    let rpcRequest: RpcRequestLifecycle | null = null
     let returnToken: string | undefined
 
     try {
@@ -493,7 +499,7 @@ export default class Amqp {
           uuidv4()
         replyTo =
           properties?.replyTo || this.config.amqpProperties?.replyTo || uuidv4()
-        cancelRpcConsumer = await this.handleRemoteProcedureCall(
+        rpcRequest = await this.handleRemoteProcedureCall(
           correlationId,
           replyTo,
         )
@@ -553,6 +559,7 @@ export default class Amqp {
           }
         },
       )
+      rpcRequest?.startTimeout()
       if (confirmation && drain) {
         await Promise.all([confirmation, drain])
       } else if (confirmation) {
@@ -571,8 +578,8 @@ export default class Amqp {
       if (returnToken) {
         this.returnedPublishes.delete(returnToken)
       }
-      if (cancelRpcConsumer) {
-        await cancelRpcConsumer()
+      if (rpcRequest) {
+        await rpcRequest.cancel()
       }
       this.node.error(`Could not publish message: ${e}`)
       throw e
@@ -594,7 +601,7 @@ export default class Amqp {
   private async handleRemoteProcedureCall(
     correlationId: string,
     replyTo: string,
-  ): Promise<() => Promise<void>> {
+  ): Promise<RpcRequestLifecycle> {
     const rpcConfig = this.getRpcConfig(replyTo)
 
     try {
@@ -672,39 +679,45 @@ export default class Amqp {
       interruptRpc = error => pendingRequest.interrupt(error, false)
       this.rpcInterruptHandlers.add(interruptRpc)
 
-      /****************************************
-       * Check if RPC has timed out and handle
-       ****************************************/
-      rpcTimeout = setTimeout(async () => {
-        clearRpcTimeout()
-        if (this.closed) {
+      const startTimeout = (): void => {
+        if (rpcResponseFinalized || rpcTimeout) {
           return
         }
 
-        try {
-          if (finalizeRpcResponse()) {
-            const unmatchedResponseCount =
-              rpcConsumer.unmatchedResponseCount
-            const unmatchedResponseDiagnostic =
-              unmatchedResponseCount > 0
-                ? ` Observed ${unmatchedResponseCount}${rpcConsumer.unmatchedResponseOverflow ? '+' : ''} unmatched RPC response${unmatchedResponseCount === 1 && !rpcConsumer.unmatchedResponseOverflow ? '' : 's'} on the shared reply consumer.`
-                : ''
-            this.node.send({
-              payload: {
-                message: `Timeout while waiting for RPC response.${unmatchedResponseDiagnostic}`,
-                config: rpcConfig,
-              },
-            })
+        /****************************************
+         * Check if RPC has timed out and handle
+         ****************************************/
+        rpcTimeout = setTimeout(async () => {
+          clearRpcTimeout()
+          if (this.closed) {
+            return
           }
-          await cleanupRpcResources()
-        } catch (e) {
-          // TODO: Keep an eye on this
-          // This might close the whole channel
-          this.node.error(`Error trying to cancel RPC consumer: ${e}`)
-        }
-      }, rpcConfig.rpcTimeout || 3000)
-      this.rpcTimeouts.add(rpcTimeout)
-      return cancelRpcConsumer
+
+          try {
+            if (finalizeRpcResponse()) {
+              const unmatchedResponseCount =
+                rpcConsumer.unmatchedResponseCount
+              const unmatchedResponseDiagnostic =
+                unmatchedResponseCount > 0
+                  ? ` Observed ${unmatchedResponseCount}${rpcConsumer.unmatchedResponseOverflow ? '+' : ''} unmatched RPC response${unmatchedResponseCount === 1 && !rpcConsumer.unmatchedResponseOverflow ? '' : 's'} on the shared reply consumer.`
+                  : ''
+              this.node.send({
+                payload: {
+                  message: `Timeout while waiting for RPC response.${unmatchedResponseDiagnostic}`,
+                  config: rpcConfig,
+                },
+              })
+            }
+            await cleanupRpcResources()
+          } catch (e) {
+            // TODO: Keep an eye on this
+            // This might close the whole channel
+            this.node.error(`Error trying to cancel RPC consumer: ${e}`)
+          }
+        }, rpcConfig.rpcTimeout || 3000)
+        this.rpcTimeouts.add(rpcTimeout)
+      }
+      return { cancel: cancelRpcConsumer, startTimeout }
     } catch (e) {
       this.node.error(`Could not consume RPC message: ${e}`)
       throw e
@@ -1043,8 +1056,8 @@ export default class Amqp {
       await this.detachRpcConsumers(interruption)
       this.clearRpcTimeouts()
 
-      await this.unbindQueues(removeBindings)
-      this.bindingsRemoved ||= removeBindings
+      const bindingsRemoved = await this.unbindQueues(removeBindings)
+      this.bindingsRemoved ||= removeBindings && bindingsRemoved
       await this.closeChannel()
       await this.releaseConnection()
     })()
@@ -1079,8 +1092,8 @@ export default class Amqp {
         await this.connect()
         connected = true
         await this.initialize()
-        await this.unbindQueues(true)
-        this.bindingsRemoved = true
+        const bindingsRemoved = await this.unbindQueues(true)
+        this.bindingsRemoved ||= bindingsRemoved
       } finally {
         if (connected) {
           this.closed = true
@@ -1103,9 +1116,10 @@ export default class Amqp {
     }
   }
 
-  private async unbindQueues(removeBindings = false): Promise<void> {
+  private async unbindQueues(removeBindings = false): Promise<boolean> {
     const { name: exchangeName } = this.config.exchange
     const queueName = this.q?.queue
+    let succeeded = true
 
     if (
       exchangeName &&
@@ -1117,11 +1131,13 @@ export default class Amqp {
         try {
           await this.channel.unbindQueue(queueName, exchangeName, routingKey)
         } catch (e) {
+          succeeded = false
           /* istanbul ignore next */
           this.node.error(`Error unbinding queue for routing key ${routingKey}: ${e.message}`)
         }
       }
     }
+    return succeeded
   }
 
   private shouldUnbindQueueOnClose(removeBindings: boolean): boolean {
@@ -1198,7 +1214,10 @@ export default class Amqp {
     brokerUrl: string,
     brokerInfo: string,
   ): Promise<ChannelModel> {
-    const connection = await connect(brokerUrl, { heartbeat: 2 })
+    const connection = await connect(brokerUrl, {
+      heartbeat: 2,
+      timeout: AMQP_CONNECTION_TIMEOUT_MS,
+    })
     this.node.log(`Connected to AMQP broker ${brokerInfo}`)
 
     const entry = { connection, count: 0 }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -392,9 +392,22 @@ export default class Amqp {
     this.config.exchange.routingKey = newRoutingKey
   }
 
+  public getVhost(): string | undefined {
+    let broker = this.broker as unknown as BrokerConfig | undefined
+    if (!broker) {
+      // Node-RED's public types omit the runtime getNode method.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      broker = this.RED.nodes.getNode(this.config.broker) as
+        | BrokerConfig
+        | undefined
+    }
+    return this.vhostOverride ?? broker?.vhost
+  }
+
   public async setVhost(newVhost: string): Promise<void> {
     const broker = this.broker as unknown as BrokerConfig
-    const currentVhost = this.vhostOverride ?? broker?.vhost
+    const currentVhost = this.getVhost()
 
     if (!broker || currentVhost === newVhost) {
       return

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -270,6 +270,13 @@ export default class Amqp {
         throw err
       } finally {
         pendingConnection.activeWaiters -= 1
+        if (
+          pendingConnection.activeWaiters === 0 &&
+          !pendingConnection.accepted &&
+          Amqp.pendingConnections.get(key) === pendingConnection
+        ) {
+          Amqp.pendingConnections.delete(key)
+        }
       }
     }
 
@@ -1168,44 +1175,111 @@ export default class Amqp {
       options instanceof Error ? options : options?.interruption
     const removeBindings =
       !(options instanceof Error) && options?.removeBindings === true
+    const cleanupDeadline = removeBindings
+      ? Date.now() + BINDING_CLEANUP_TIMEOUT_MS
+      : undefined
     if (this.bindingCleanupPromise) {
       await this.bindingCleanupPromise
       return
     }
     if (this.closed) {
-      await this.closePromise
+      let priorCloseError: unknown
       if (removeBindings) {
-        await this.removeBindingsAfterClose()
+        try {
+          await this.awaitCleanupOperation(
+            Promise.resolve(this.closePromise),
+            cleanupDeadline as number,
+            'finish existing close',
+          )
+        } catch (error) {
+          priorCloseError = error
+        }
+      } else {
+        await this.closePromise
+      }
+      if (removeBindings) {
+        await this.removeBindingsAfterClose(
+          BINDING_CLEANUP_MAX_ATTEMPTS,
+          cleanupDeadline,
+          priorCloseError,
+        )
       }
       return
     }
     this.closed = true
     this.lifecycleVersion += 1
     const closeOperation = (async (): Promise<void> => {
+      let cleanupError: unknown
       if (interruption) {
         for (const interruptRpc of [...this.rpcInterruptHandlers]) {
           interruptRpc(interruption)
         }
       }
 
-      await this.detachRpcConsumers(interruption)
+      if (removeBindings) {
+        try {
+          await this.awaitCleanupOperation(
+            this.detachRpcConsumers(interruption),
+            cleanupDeadline as number,
+            'detach RPC consumers',
+          )
+        } catch (error) {
+          cleanupError = error
+        }
+      } else {
+        await this.detachRpcConsumers(interruption)
+      }
       this.clearRpcTimeouts()
 
       let bindingsRemoved = false
-      try {
-        bindingsRemoved = await this.unbindQueues(removeBindings)
-        this.bindingsRemoved ||= removeBindings && bindingsRemoved
-      } finally {
+      if (removeBindings) {
         try {
-          await this.closeChannel()
+          bindingsRemoved = await this.awaitCleanupOperation(
+            this.unbindQueues(true),
+            cleanupDeadline as number,
+            'unbind queues',
+          )
+          this.bindingsRemoved ||= bindingsRemoved
+        } catch (error) {
+          cleanupError = error
+        }
+        try {
+          await this.awaitCleanupOperation(
+            this.closeChannel(),
+            cleanupDeadline as number,
+            'close channel',
+          )
+        } catch (error) {
+          cleanupError ??= error
+        }
+        try {
+          await this.awaitCleanupOperation(
+            this.releaseConnection(),
+            cleanupDeadline as number,
+            'release connection',
+          )
+        } catch (error) {
+          cleanupError ??= error
+        }
+      } else {
+        try {
+          bindingsRemoved = await this.unbindQueues(false)
         } finally {
-          await this.releaseConnection()
+          try {
+            await this.closeChannel()
+          } finally {
+            await this.releaseConnection()
+          }
         }
       }
       if (removeBindings && !bindingsRemoved) {
         await this.removeBindingsAfterClose(
           BINDING_CLEANUP_MAX_ATTEMPTS - 1,
+          cleanupDeadline,
+          cleanupError,
         )
+      } else if (cleanupError) {
+        throw cleanupError
       }
     })()
     this.closePromise = closeOperation
@@ -1220,6 +1294,8 @@ export default class Amqp {
 
   private async removeBindingsAfterClose(
     maxAttempts = BINDING_CLEANUP_MAX_ATTEMPTS,
+    deadline = Date.now() + BINDING_CLEANUP_TIMEOUT_MS,
+    initialError?: unknown,
   ): Promise<void> {
     const { name: exchangeName } = this.config.exchange
     if (
@@ -1236,8 +1312,7 @@ export default class Amqp {
     }
 
     const cleanupOperation = (async (): Promise<void> => {
-      let lastError: unknown
-      const deadline = Date.now() + BINDING_CLEANUP_TIMEOUT_MS
+      let lastError: unknown = initialError
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         const remainingTime = deadline - Date.now()
         if (remainingTime <= 0) {
@@ -1247,8 +1322,18 @@ export default class Amqp {
         try {
           await this.connect({ timeout: remainingTime })
           connected = true
-          await this.createChannel()
-          if (await this.unbindQueues(true)) {
+          await this.awaitCleanupOperation(
+            this.createChannel(),
+            deadline,
+            'create cleanup channel',
+          )
+          if (
+            await this.awaitCleanupOperation(
+              this.unbindQueues(true),
+              deadline,
+              'unbind queues',
+            )
+          ) {
             this.bindingsRemoved = true
             return
           }
@@ -1260,9 +1345,17 @@ export default class Amqp {
             this.closed = true
             this.lifecycleVersion += 1
             try {
-              await this.closeChannel()
+              await this.awaitCleanupOperation(
+                this.closeChannel(),
+                deadline,
+                'close cleanup channel',
+              )
             } finally {
-              await this.releaseConnection()
+              await this.awaitCleanupOperation(
+                this.releaseConnection(),
+                deadline,
+                'release cleanup connection',
+              )
             }
           }
         }
@@ -1282,6 +1375,35 @@ export default class Amqp {
     } finally {
       if (this.bindingCleanupPromise === cleanupOperation) {
         this.bindingCleanupPromise = null
+      }
+    }
+  }
+
+  private async awaitCleanupOperation<T>(
+    operation: Promise<T>,
+    deadline: number,
+    operationName: string,
+  ): Promise<T> {
+    const remainingTime = Math.max(0, deadline - Date.now())
+    let timeoutHandle: NodeJS.Timeout | undefined
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `AMQP binding cleanup timed out while attempting to ${operationName}`,
+                ),
+              ),
+            remainingTime,
+          )
+        }),
+      ])
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
       }
     }
   }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -31,6 +31,7 @@ const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
 const AMQP_CONNECTION_TIMEOUT_MS = 5_000
+const BINDING_CLEANUP_MAX_ATTEMPTS = 3
 
 type TrackedAssembledMessage = AssembledMessage & {
   [DELIVERY_TOKEN]?: string
@@ -72,6 +73,10 @@ interface RpcConsumerState {
 interface AmqpCloseOptions {
   interruption?: Error
   removeBindings?: boolean
+}
+
+interface AmqpConnectOptions {
+  timeout?: number
 }
 
 interface ChannelDrainGate {
@@ -154,7 +159,9 @@ export default class Amqp {
     }
   }
 
-  public async connect(): Promise<ChannelModel> {
+  public async connect(
+    options: AmqpConnectOptions = {},
+  ): Promise<ChannelModel> {
     const { broker } = this.config
 
     // wtf happened to the types?
@@ -194,6 +201,7 @@ export default class Amqp {
           key,
           brokerUrl,
           brokerInfo,
+          options.timeout,
         )
         Amqp.pendingConnections.set(key, pendingConnection)
       }
@@ -485,7 +493,15 @@ export default class Amqp {
     } = config
 
     let rpcRequest: RpcRequestLifecycle | null = null
+    let rpcAdmissionController: AbortController | null = null
+    let rpcAdmissionTimeout: NodeJS.Timeout | null = null
     let returnToken: string | undefined
+    const clearRpcAdmissionTimeout = (): void => {
+      if (rpcAdmissionTimeout) {
+        clearTimeout(rpcAdmissionTimeout)
+        rpcAdmissionTimeout = null
+      }
+    }
 
     try {
       let correlationId = ''
@@ -503,6 +519,12 @@ export default class Amqp {
           correlationId,
           replyTo,
         )
+        rpcAdmissionController = new AbortController()
+        rpcAdmissionTimeout = setTimeout(() => {
+          rpcAdmissionController?.abort(
+            new Error('Timeout while waiting to publish RPC request'),
+          )
+        }, config.rpcTimeout || 3000)
       }
 
       const options = {
@@ -558,7 +580,9 @@ export default class Amqp {
                 : null,
           }
         },
+        rpcAdmissionController?.signal,
       )
+      clearRpcAdmissionTimeout()
       rpcRequest?.startTimeout()
       if (confirmation && drain) {
         await Promise.all([confirmation, drain])
@@ -575,6 +599,7 @@ export default class Amqp {
         }
       }
     } catch (e) {
+      clearRpcAdmissionTimeout()
       if (returnToken) {
         this.returnedPublishes.delete(returnToken)
       }
@@ -904,8 +929,11 @@ export default class Amqp {
     }
   }
 
-  private async waitForWritableChannel(): Promise<Channel> {
+  private async waitForWritableChannel(
+    signal?: AbortSignal,
+  ): Promise<Channel> {
     while (true) {
+      this.throwIfWriteAborted(signal)
       const channel = this.channel
       const failure = this.channelWriteFailure
       if (failure?.channel === channel) {
@@ -915,13 +943,15 @@ export default class Amqp {
       if (!gate || gate.channel !== channel) {
         return channel
       }
-      await gate.promise
+      await this.waitForWriteAdmission(gate.promise, signal)
     }
   }
 
   private async writeWithBackpressure<T>(
     write: (channel: Channel) => T,
+    signal?: AbortSignal,
   ): Promise<T> {
+    this.throwIfWriteAborted(signal)
     const initialChannel = this.channel
     const failure = this.channelWriteFailure
     if (failure?.channel === initialChannel) {
@@ -933,9 +963,9 @@ export default class Amqp {
       return write(initialChannel)
     }
 
-    const release = await this.acquireChannelWrite(initialChannel)
+    const release = await this.acquireChannelWrite(initialChannel, signal)
     try {
-      const channel = await this.waitForWritableChannel()
+      const channel = await this.waitForWritableChannel(signal)
       if (this.closed) {
         throw new Error('AMQP channel closed while waiting for write buffer')
       }
@@ -945,7 +975,11 @@ export default class Amqp {
     }
   }
 
-  private async acquireChannelWrite(channel: Channel): Promise<() => void> {
+  private async acquireChannelWrite(
+    channel: Channel,
+    signal?: AbortSignal,
+  ): Promise<() => void> {
+    this.throwIfWriteAborted(signal)
     const previous =
       this.channelWriteQueue?.channel === channel
         ? this.channelWriteQueue.tail
@@ -959,7 +993,17 @@ export default class Amqp {
       tail: previous.then(() => ticket),
     }
     this.channelWriteQueue = queue
-    await previous
+    try {
+      await this.waitForWriteAdmission(previous, signal)
+    } catch (error) {
+      release()
+      void queue.tail.then(() => {
+        if (this.channelWriteQueue === queue) {
+          this.channelWriteQueue = null
+        }
+      })
+      throw error
+    }
 
     return () => {
       release()
@@ -967,6 +1011,46 @@ export default class Amqp {
         this.channelWriteQueue = null
       }
     }
+  }
+
+  private throwIfWriteAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) {
+      return
+    }
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error('AMQP write admission cancelled')
+  }
+
+  private async waitForWriteAdmission<T>(
+    promise: Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (!signal) {
+      return promise
+    }
+    this.throwIfWriteAborted(signal)
+
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = (): void => {
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new Error('AMQP write admission cancelled'),
+        )
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+      promise.then(
+        value => {
+          signal.removeEventListener('abort', onAbort)
+          resolve(value)
+        },
+        error => {
+          signal.removeEventListener('abort', onAbort)
+          reject(error)
+        },
+      )
+    })
   }
 
   private getChannelDrainGate(channel: Channel): Promise<void> {
@@ -1056,10 +1140,22 @@ export default class Amqp {
       await this.detachRpcConsumers(interruption)
       this.clearRpcTimeouts()
 
-      const bindingsRemoved = await this.unbindQueues(removeBindings)
-      this.bindingsRemoved ||= removeBindings && bindingsRemoved
-      await this.closeChannel()
-      await this.releaseConnection()
+      let bindingsRemoved = false
+      try {
+        bindingsRemoved = await this.unbindQueues(removeBindings)
+        this.bindingsRemoved ||= removeBindings && bindingsRemoved
+      } finally {
+        try {
+          await this.closeChannel()
+        } finally {
+          await this.releaseConnection()
+        }
+      }
+      if (removeBindings && !bindingsRemoved) {
+        await this.removeBindingsAfterClose(
+          BINDING_CLEANUP_MAX_ATTEMPTS - 1,
+        )
+      }
     })()
     this.closePromise = closeOperation
     try {
@@ -1071,7 +1167,9 @@ export default class Amqp {
     }
   }
 
-  private async removeBindingsAfterClose(): Promise<void> {
+  private async removeBindingsAfterClose(
+    maxAttempts = BINDING_CLEANUP_MAX_ATTEMPTS,
+  ): Promise<void> {
     const { name: exchangeName } = this.config.exchange
     if (
       this.bindingsRemoved ||
@@ -1087,24 +1185,31 @@ export default class Amqp {
     }
 
     const cleanupOperation = (async (): Promise<void> => {
-      let connected = false
-      try {
-        await this.connect()
-        connected = true
-        await this.initialize()
-        const bindingsRemoved = await this.unbindQueues(true)
-        this.bindingsRemoved ||= bindingsRemoved
-      } finally {
-        if (connected) {
-          this.closed = true
-          this.lifecycleVersion += 1
-          try {
-            await this.closeChannel()
-          } finally {
-            await this.releaseConnection()
+      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        let connected = false
+        try {
+          await this.connect({ timeout: AMQP_CONNECTION_TIMEOUT_MS })
+          connected = true
+          await this.initialize()
+          if (await this.unbindQueues(true)) {
+            this.bindingsRemoved = true
+            return
+          }
+        } finally {
+          if (connected) {
+            this.closed = true
+            this.lifecycleVersion += 1
+            try {
+              await this.closeChannel()
+            } finally {
+              await this.releaseConnection()
+            }
           }
         }
       }
+      throw new Error(
+        `Could not remove AMQP bindings after ${BINDING_CLEANUP_MAX_ATTEMPTS} attempts`,
+      )
     })()
     this.bindingCleanupPromise = cleanupOperation
     try {
@@ -1213,11 +1318,15 @@ export default class Amqp {
     key: string,
     brokerUrl: string,
     brokerInfo: string,
+    timeout?: number,
   ): Promise<ChannelModel> {
-    const connection = await connect(brokerUrl, {
+    const socketOptions: { heartbeat: number; timeout?: number } = {
       heartbeat: 2,
-      timeout: AMQP_CONNECTION_TIMEOUT_MS,
-    })
+    }
+    if (timeout !== undefined) {
+      socketOptions.timeout = timeout
+    }
+    const connection = await connect(brokerUrl, socketOptions)
     this.node.log(`Connected to AMQP broker ${brokerInfo}`)
 
     const entry = { connection, count: 0 }

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -30,7 +30,7 @@ import { NODE_STATUS } from './constants'
 const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
-const AMQP_CONNECTION_TIMEOUT_MS = 5_000
+const BINDING_CLEANUP_TIMEOUT_MS = 5_000
 const BINDING_CLEANUP_MAX_ATTEMPTS = 3
 
 type TrackedAssembledMessage = AssembledMessage & {
@@ -79,6 +79,12 @@ interface AmqpConnectOptions {
   timeout?: number
 }
 
+interface PendingConnection {
+  promise: Promise<ChannelModel>
+  activeWaiters: number
+  accepted: boolean
+}
+
 interface ChannelDrainGate {
   channel: Channel
   promise: Promise<void>
@@ -97,8 +103,13 @@ export default class Amqp {
   private channel: Channel
   private q: Replies.AssertQueue
   private vhostOverride?: string
+  private connectionPoolKey?: string
   private static connectionPool: Map<string, { connection: ChannelModel; count: number }> = new Map()
-  private static pendingConnections: Map<string, Promise<ChannelModel>> = new Map()
+  private static pendingConnections: Map<string, PendingConnection> = new Map()
+  private static endpointGenerations: Map<
+    string,
+    { brokerUrl: string; generation: number }
+  > = new Map()
   private static rpcConsumerRegistries: WeakMap<
     object,
     Map<string, RpcConsumerState>
@@ -185,7 +196,8 @@ export default class Amqp {
     const { host, port, vhost } = brokerConfig
 
     const brokerInfo = `${host}:${port}${vhost ? `/${vhost}` : ''}`
-    const key = `${broker}:${vhost}`
+    const logicalKey = `${broker}:${vhost}`
+    const key = this.getEndpointGenerationKey(logicalKey, brokerUrl)
 
     let entry = Amqp.connectionPool.get(key)
     if (entry && !this.isConnectionOpen(entry.connection)) {
@@ -197,14 +209,28 @@ export default class Amqp {
       let pendingConnection = Amqp.pendingConnections.get(key)
       if (!pendingConnection) {
         this.node.log(`Connecting to AMQP broker ${brokerInfo}`)
-        pendingConnection = this.createPooledConnection(
-          key,
-          brokerUrl,
-          brokerInfo,
-        )
+        pendingConnection = {
+          promise: this.createPooledConnection(brokerUrl, brokerInfo),
+          activeWaiters: 0,
+          accepted: false,
+        }
         Amqp.pendingConnections.set(key, pendingConnection)
-        void pendingConnection.then(
-          () => {
+        void pendingConnection.promise.then(
+          async connection => {
+            if (
+              !pendingConnection.accepted &&
+              pendingConnection.activeWaiters === 0
+            ) {
+              if (Amqp.pendingConnections.get(key) === pendingConnection) {
+                Amqp.pendingConnections.delete(key)
+              }
+              try {
+                await connection.close()
+              } catch (error) {
+                this.node.error(`Error closing unowned AMQP connection: ${error}`)
+              }
+              return
+            }
             if (Amqp.pendingConnections.get(key) === pendingConnection) {
               Amqp.pendingConnections.delete(key)
             }
@@ -217,25 +243,39 @@ export default class Amqp {
         )
       }
 
+      pendingConnection.activeWaiters += 1
       try {
         const connection = await this.awaitConnection(
-          pendingConnection,
+          pendingConnection.promise,
           brokerInfo,
           options.timeout,
         )
         entry = Amqp.connectionPool.get(key)
-        if (!entry || entry.connection !== connection) {
+        if (!entry) {
+          pendingConnection.accepted = true
+          entry = { connection, count: 0 }
+          Amqp.connectionPool.set(key, entry)
+          connection.on('close', () => {
+            const current = Amqp.connectionPool.get(key)
+            if (current?.connection === connection) {
+              Amqp.connectionPool.delete(key)
+            }
+          })
+        } else if (entry.connection !== connection) {
           throw new Error(`AMQP connection closed while connecting to ${brokerInfo}`)
         }
       } catch (err) {
         this.setBrokerNodeState('errored', err)
         this.node.warn(`Failed to connect to AMQP broker ${brokerInfo}: ${err}`)
         throw err
+      } finally {
+        pendingConnection.activeWaiters -= 1
       }
     }
 
     entry.count += 1
     this.connection = entry.connection
+    this.connectionPoolKey = key
 
     this.connectionErrorHandler = (e): void => {
       /* istanbul ignore next */
@@ -1197,10 +1237,15 @@ export default class Amqp {
 
     const cleanupOperation = (async (): Promise<void> => {
       let lastError: unknown
+      const deadline = Date.now() + BINDING_CLEANUP_TIMEOUT_MS
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        const remainingTime = deadline - Date.now()
+        if (remainingTime <= 0) {
+          break
+        }
         let connected = false
         try {
-          await this.connect({ timeout: AMQP_CONNECTION_TIMEOUT_MS })
+          await this.connect({ timeout: remainingTime })
           connected = true
           await this.createChannel()
           if (await this.unbindQueues(true)) {
@@ -1220,6 +1265,9 @@ export default class Amqp {
               await this.releaseConnection()
             }
           }
+        }
+        if (Date.now() >= deadline) {
+          break
         }
       }
       const cleanupError = new Error(
@@ -1325,7 +1373,7 @@ export default class Amqp {
     const brokerId = this.config.broker
     const broker = this.broker as unknown as BrokerConfig
     const vhost = this.vhostOverride ?? broker?.vhost
-    const key = `${brokerId}:${vhost}`
+    const key = this.connectionPoolKey ?? `${brokerId}:${vhost}`
 
     this.setBrokerNodeState('disconnected')
     this.node.status(NODE_STATUS.Disconnected)
@@ -1348,26 +1396,34 @@ export default class Amqp {
         }
       }
     }
+    this.connectionPoolKey = undefined
   }
 
   private async createPooledConnection(
-    key: string,
     brokerUrl: string,
     brokerInfo: string,
   ): Promise<ChannelModel> {
     const connection = await connect(brokerUrl, { heartbeat: 2 })
     this.node.log(`Connected to AMQP broker ${brokerInfo}`)
-
-    const entry = { connection, count: 0 }
-    Amqp.connectionPool.set(key, entry)
-    connection.on('close', () => {
-      const current = Amqp.connectionPool.get(key)
-      if (current?.connection === connection) {
-        Amqp.connectionPool.delete(key)
-      }
-    })
-
     return connection
+  }
+
+  private getEndpointGenerationKey(
+    logicalKey: string,
+    brokerUrl: string,
+  ): string {
+    const current = Amqp.endpointGenerations.get(logicalKey)
+    if (!current) {
+      Amqp.endpointGenerations.set(logicalKey, { brokerUrl, generation: 0 })
+      return logicalKey
+    }
+    if (current.brokerUrl !== brokerUrl) {
+      current.brokerUrl = brokerUrl
+      current.generation += 1
+    }
+    return current.generation === 0
+      ? logicalKey
+      : `${logicalKey}#${current.generation}`
   }
 
   private async awaitConnection(

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -104,6 +104,7 @@ export default class Amqp {
   private channel: Channel
   private q: Replies.AssertQueue
   private vhostOverride?: string
+  private initializedVhost?: string
   private connectionPoolKey?: string
   private static connectionPool: Map<string, { connection: ChannelModel; count: number }> = new Map()
   private static pendingConnections: Map<string, PendingConnection> = new Map()
@@ -297,6 +298,7 @@ export default class Amqp {
     }
 
     this.connectionCloseHandler = (): void => {
+      this.initializedVhost = undefined
       /* istanbul ignore next */
       this.setBrokerNodeState('disconnected', new Error('AMQP connection closed'))
       this.node.status(NODE_STATUS.Disconnected)
@@ -341,11 +343,13 @@ export default class Amqp {
       }
       return this.channel
     })()
-    return this.awaitAbortable(
+    const channel = await this.awaitAbortable(
       initialization,
       options.signal,
       'AMQP channel initialization was cancelled',
     )
+    this.initializedVhost = this.getVhost()
+    return channel
   }
 
   public async consume(): Promise<void> {
@@ -405,11 +409,19 @@ export default class Amqp {
     return this.vhostOverride ?? broker?.vhost
   }
 
+  public isInitializedForVhost(vhost: string): boolean {
+    return (
+      !this.closed &&
+      !!this.connection &&
+      !!this.channel &&
+      this.initializedVhost === vhost
+    )
+  }
+
   public async setVhost(newVhost: string): Promise<void> {
     const broker = this.broker as unknown as BrokerConfig
-    const currentVhost = this.getVhost()
 
-    if (!broker || currentVhost === newVhost) {
+    if (!broker || this.isInitializedForVhost(newVhost)) {
       return
     }
 
@@ -420,6 +432,7 @@ export default class Amqp {
       await this.initialize()
       this.markConnected()
     } catch (e) {
+      await this.close().catch(() => undefined)
       this.node.error(`Could not switch vhost: ${e}`)
       throw e
     }
@@ -1234,6 +1247,7 @@ export default class Amqp {
       return
     }
     this.closed = true
+    this.initializedVhost = undefined
     this.lifecycleVersion += 1
     const closeOperation = (async (): Promise<void> => {
       let cleanupError: unknown
@@ -1672,6 +1686,7 @@ export default class Amqp {
     }
 
     this.channelCloseHandler = (): void => {
+      this.initializedVhost = undefined
       /* istanbul ignore next */
       this.node.status(NODE_STATUS.Disconnected)
       this.node.log('AMQP Channel closed')

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -27,7 +27,7 @@ import {
 } from './types'
 import { NODE_STATUS } from './constants'
 import DeliverySettlementTracker from './delivery-settlement-tracker'
-import { brokerUrl, parseJson as parseTransportJson, parseJsonObject as parseTransportJsonObject, routingKeys } from './amqp-transport-utils'
+import { brokerUrl, parseJsonObject as parseTransportJsonObject, routingKeys } from './amqp-transport-utils'
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
 const BINDING_CLEANUP_TIMEOUT_MS = 5_000
@@ -1834,8 +1834,9 @@ export default class Amqp {
   }
 
   private parseJson(jsonInput: unknown, logError = false): JsonValue {
+    if (typeof jsonInput !== 'string') return jsonInput as JsonValue
     try {
-      return parseTransportJson(jsonInput)
+      return JSON.parse(jsonInput) as JsonValue
     } catch (e) {
       if (logError) this.node.error(`Invalid JSON payload: ${e}`)
       return jsonInput as JsonValue

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -27,6 +27,7 @@ import {
 } from './types'
 import { NODE_STATUS } from './constants'
 import DeliverySettlementTracker from './delivery-settlement-tracker'
+import { brokerUrl, parseJson as parseTransportJson, parseJsonObject as parseTransportJsonObject, routingKeys } from './amqp-transport-utils'
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
 const BINDING_CLEANUP_TIMEOUT_MS = 5_000
@@ -1777,23 +1778,11 @@ export default class Amqp {
   }
 
   private getBrokerUrl(broker: BrokerConfig): string {
-    let url = ''
-
-    if (broker) {
-      const { host, port, vhost, tls, credsFromSettings, credentials } = broker
-
-      const { username, password } = credsFromSettings
-        ? this.getCredsFromSettings()
-        : credentials
-
-      const protocol = tls ? /* istanbul ignore next */ 'amqps' : 'amqp'
-      const vhostPath = vhost ? `/${encodeURIComponent(vhost)}` : '/'
-      url = `${protocol}://${encodeURIComponent(username)}:${encodeURIComponent(
-        password,
-      )}@${host}:${port}${vhostPath}`
-    }
-
-    return url
+    if (!broker) return ''
+    const credentials = broker.credsFromSettings
+      ? this.getCredsFromSettings()
+      : broker.credentials
+    return brokerUrl(broker, credentials)
   }
 
   private getCredsFromSettings(): {
@@ -1811,10 +1800,7 @@ export default class Amqp {
   }
 
   private parseRoutingKeys(routingKeyArg?: string): string[] {
-    const routingKey =
-      routingKeyArg || this.config.exchange.routingKey || this.q?.queue || ''
-    const keys = routingKey?.split(',').map(key => key.trim())
-    return keys
+    return routingKeys(routingKeyArg, this.config.exchange.routingKey, this.q?.queue)
   }
 
   private assembleMessage(amqpMessage: ConsumeMessage): AssembledMessage {
@@ -1848,22 +1834,20 @@ export default class Amqp {
   }
 
   private parseJson(jsonInput: unknown, logError = false): JsonValue {
-    let output: unknown
     try {
-      output = JSON.parse(jsonInput as string)
+      return parseTransportJson(jsonInput)
     } catch (e) {
-      output = jsonInput
-      /* istanbul ignore next */
-      if (logError) {
-        this.node.error(`Invalid JSON payload: ${e}`)
-      }
+      if (logError) this.node.error(`Invalid JSON payload: ${e}`)
+      return jsonInput as JsonValue
     }
-    return output as JsonValue
   }
 
   private parseJsonObject(jsonInput: unknown, logError = false): JsonObject {
-    const output = this.parseJson(jsonInput, logError)
-    return this.isJsonObject(output) ? output : {}
+    if (logError) {
+      const output = this.parseJson(jsonInput, true)
+      return this.isJsonObject(output) ? output : {}
+    }
+    return parseTransportJsonObject(jsonInput)
   }
 
   private isJsonObject(value: JsonValue): value is JsonObject {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -26,22 +26,11 @@ import {
   BrokerNodeError,
 } from './types'
 import { NODE_STATUS } from './constants'
-
-const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
+import DeliverySettlementTracker from './delivery-settlement-tracker'
 const RETURN_TOKEN_HEADER = 'x-node-red-contrib-amqp-return-token'
 const MAX_UNMATCHED_RPC_RESPONSES = 100
 const BINDING_CLEANUP_TIMEOUT_MS = 5_000
 const BINDING_CLEANUP_MAX_ATTEMPTS = 3
-
-type TrackedAssembledMessage = AssembledMessage & {
-  [DELIVERY_TOKEN]?: string
-}
-
-interface TrackedDelivery {
-  message: AssembledMessage
-  channel: Channel
-  deliveryTag: number
-}
 
 interface PendingRpcRequest {
   owner: Amqp
@@ -125,7 +114,7 @@ export default class Amqp {
   private rpcInterruptHandlers: Set<(error: Error) => void> = new Set()
   private rpcConsumers: Map<string, RpcConsumerState> = new Map()
   private returnedPublishes: Map<string, Error> = new Map()
-  private trackedDeliveries: Map<string, TrackedDelivery> = new Map()
+  private readonly deliveryTracker: DeliverySettlementTracker
   private closed = false
   private closePromise: Promise<void> | null = null
   private bindingCleanupPromise: Promise<void> | null = null
@@ -170,6 +159,7 @@ export default class Amqp {
       outputs: config.outputs,
       rpcTimeout: config.rpcTimeoutMilliseconds,
     }
+    this.deliveryTracker = new DeliverySettlementTracker(this.node)
   }
 
   public async connect(
@@ -285,7 +275,6 @@ export default class Amqp {
         }
       }
     }
-
     entry.count += 1
     this.connection = entry.connection
     this.connectionPoolKey = key
@@ -477,7 +466,7 @@ export default class Amqp {
     try {
       this.node.log('Acking all outstanding messages')
       this.channel.ackAll()
-      this.trackedDeliveries.clear()
+      this.deliveryTracker.clear()
       return true
     } catch (e) {
       this.node.error(`Could not ackAll messages: ${e}`)
@@ -513,7 +502,7 @@ export default class Amqp {
     try {
       this.node.log('Nacking all outstanding messages')
       this.channel.nackAll(requeue)
-      this.trackedDeliveries.clear()
+      this.deliveryTracker.clear()
       return true
     } catch (e) {
       this.node.error(`Could not nackAll messages: ${e}`)
@@ -1517,7 +1506,7 @@ export default class Amqp {
   }
 
   private async closeChannel(): Promise<void> {
-    this.trackedDeliveries.clear()
+    this.deliveryTracker.clear()
     this.returnedPublishes.clear()
     this.rpcInterruptHandlers.clear()
     if (this.channel) {
@@ -1666,7 +1655,7 @@ export default class Amqp {
     const { prefetch, waitForConfirms } = this.config
     const lifecycleVersion = this.lifecycleVersion
 
-    this.trackedDeliveries.clear()
+    this.deliveryTracker.clear()
     const channel = await (waitForConfirms
       ? this.connection.createConfirmChannel()
       : this.connection.createChannel())
@@ -1830,18 +1819,9 @@ export default class Amqp {
 
   private assembleMessage(amqpMessage: ConsumeMessage): AssembledMessage {
     const payload = this.parseJson(amqpMessage.content.toString(), true)
-    const msg = amqpMessage as TrackedAssembledMessage
+    const msg = amqpMessage as AssembledMessage
     msg.payload = payload
-    if (this.isManualAck()) {
-      const token = uuidv4()
-      msg[DELIVERY_TOKEN] = token
-      this.trackedDeliveries.set(token, {
-        message: msg,
-        channel: this.channel,
-        deliveryTag: msg.fields.deliveryTag,
-      })
-    }
-    return msg
+    return this.deliveryTracker.track(msg, this.channel, this.isManualAck())
   }
 
   private isManualAck(): boolean {
@@ -1851,50 +1831,20 @@ export default class Amqp {
   private resolveDelivery(
     msg: AssembledMessage,
     operation: string,
-  ): (TrackedDelivery & { token?: string }) | null {
-    if (!this.isManualAck()) {
-      return {
-        message: msg,
-        channel: this.channel,
-        deliveryTag: msg.fields?.deliveryTag ?? 0,
-      }
-    }
-
-    const token = (msg as TrackedAssembledMessage)[DELIVERY_TOKEN]
-    const delivery = token ? this.trackedDeliveries.get(token) : undefined
-    if (!delivery || delivery.channel !== this.channel) {
-      this.node.error(
-        `Could not ${operation} message: delivery does not belong to the active AMQP channel`,
-      )
-      return null
-    }
-
-    return { ...delivery, token }
+  ): ReturnType<DeliverySettlementTracker['resolve']> {
+    return this.deliveryTracker.resolve(
+      msg,
+      operation,
+      this.channel,
+      this.isManualAck(),
+    )
   }
 
   private removeTrackedDeliveries(
-    delivery: TrackedDelivery & { token?: string },
+    delivery: NonNullable<ReturnType<DeliverySettlementTracker['resolve']>>,
     allUpTo: boolean,
   ): void {
-    if (!this.isManualAck()) {
-      return
-    }
-
-    if (!allUpTo) {
-      if (delivery.token) {
-        this.trackedDeliveries.delete(delivery.token)
-      }
-      return
-    }
-
-    for (const [token, trackedDelivery] of this.trackedDeliveries) {
-      if (
-        trackedDelivery.channel === delivery.channel &&
-        trackedDelivery.deliveryTag <= delivery.deliveryTag
-      ) {
-        this.trackedDeliveries.delete(token)
-      }
-    }
+    this.deliveryTracker.remove(delivery, allUpTo, this.isManualAck())
   }
 
   private parseJson(jsonInput: unknown, logError = false): JsonValue {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -418,7 +418,10 @@ export default class Amqp {
     )
   }
 
-  public async setVhost(newVhost: string): Promise<void> {
+  public async setVhost(
+    newVhost: string,
+    options: Pick<AmqpConnectOptions, 'signal'> = {},
+  ): Promise<void> {
     const broker = this.broker as unknown as BrokerConfig
 
     if (!broker || this.isInitializedForVhost(newVhost)) {
@@ -428,8 +431,8 @@ export default class Amqp {
     try {
       await this.close(new Error('AMQP virtual host changed during RPC'))
       this.vhostOverride = newVhost
-      await this.connect()
-      await this.initialize()
+      await this.connect(options)
+      await this.initialize(options)
       this.markConnected()
     } catch (e) {
       await this.close().catch(() => undefined)

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -436,7 +436,9 @@ export default class Amqp {
       this.markConnected()
     } catch (e) {
       await this.close().catch(() => undefined)
-      this.node.error(`Could not switch vhost: ${e}`)
+      if (!options.signal?.aborted) {
+        this.node.error(`Could not switch vhost: ${e}`)
+      }
       throw e
     }
   }

--- a/src/amqp-lifecycle-coordinator.ts
+++ b/src/amqp-lifecycle-coordinator.ts
@@ -1,0 +1,203 @@
+import { Node } from 'node-red'
+import ReconnectBackoff from './reconnect-backoff'
+
+export interface LifecycleAttempt {
+  signal: AbortSignal
+  isStale: () => boolean
+}
+
+interface LifecycleCoordinatorOptions {
+  node: Node
+  initialize: (attempt: LifecycleAttempt) => Promise<void>
+  close: (interruption?: Error) => Promise<void>
+  removeEventListeners: () => void
+  clearResources: () => void
+  onInitializationError: (error: unknown, recovering: boolean) => Promise<void>
+  reconnectInterruption?: Error
+}
+
+export default class AmqpLifecycleCoordinator {
+  private generation = 0
+  private initializationPromise: Promise<void> | null = null
+  private abortController: AbortController | null = null
+  private reconnectTimeout?: NodeJS.Timeout
+  private reconnectScheduled = false
+  private recovering = false
+  private shuttingDown = false
+  private readonly backoff = new ReconnectBackoff()
+
+  public constructor(private readonly options: LifecycleCoordinatorOptions) {}
+
+  public start(): Promise<void> {
+    return this.queueInitialization()
+  }
+
+  public isShuttingDown(): boolean {
+    return this.shuttingDown
+  }
+
+  public isRecovering(): boolean {
+    return this.recovering
+  }
+
+  public async awaitInitialization(): Promise<void> {
+    await this.initializationPromise?.catch(() => undefined)
+  }
+
+  public supersede(reason: Error): void {
+    this.generation += 1
+    clearTimeout(this.reconnectTimeout)
+    this.reconnectScheduled = false
+    this.abortController?.abort(reason)
+  }
+
+  public async replace(
+    reason: Error,
+    operation: (attempt: LifecycleAttempt) => Promise<void>,
+  ): Promise<boolean> {
+    this.supersede(reason)
+    await this.awaitInitialization()
+    if (this.shuttingDown) {
+      return false
+    }
+
+    this.supersede(reason)
+    const attemptGeneration = this.generation
+    const abortController = new AbortController()
+    this.abortController = abortController
+    const isStale = (): boolean =>
+      this.shuttingDown || attemptGeneration !== this.generation
+
+    try {
+      await operation({ signal: abortController.signal, isStale })
+      if (isStale()) {
+        await this.options.close().catch(() => undefined)
+        return false
+      }
+      this.markConnected()
+      return true
+    } finally {
+      if (this.abortController === abortController) {
+        this.abortController = null
+      }
+    }
+  }
+
+  public async reconnect(continueUntilConnected = false): Promise<void> {
+    this.recovering ||= continueUntilConnected
+    if (this.shuttingDown || this.reconnectScheduled) {
+      if (this.shuttingDown) {
+        this.options.node.log('Reconnect skipped: node is shutting down')
+      }
+      return
+    }
+
+    this.generation += 1
+    const reconnectGeneration = this.generation
+    this.abortController?.abort(
+      new Error('AMQP initialization cancelled for reconnect'),
+    )
+    this.reconnectScheduled = true
+    clearTimeout(this.reconnectTimeout)
+
+    try {
+      this.options.node.log('Reconnect requested: closing AMQP resources')
+      this.options.removeEventListeners()
+      await this.options.close(this.options.reconnectInterruption)
+      if (
+        this.shuttingDown ||
+        reconnectGeneration !== this.generation ||
+        !this.reconnectScheduled
+      ) {
+        this.reconnectScheduled = false
+        this.options.node.log(
+          'Reconnect aborted: request was superseded while closing AMQP resources',
+        )
+        return
+      }
+
+      this.options.clearResources()
+      const reconnectDelayMs = this.backoff.nextDelayMs()
+      this.options.node.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
+      this.reconnectTimeout = setTimeout(() => {
+        if (this.shuttingDown) {
+          this.reconnectScheduled = false
+          this.options.node.log('Reconnect timer fired but node is shutting down')
+          return
+        }
+        this.options.node.log('Reconnect timer fired: re-initializing AMQP node')
+        void this.queueInitialization(true)
+      }, reconnectDelayMs)
+    } catch (error) {
+      this.reconnectScheduled = false
+      throw error
+    }
+  }
+
+  public shutdown(reason: Error): void {
+    this.shuttingDown = true
+    this.supersede(reason)
+    this.options.removeEventListeners()
+  }
+
+  public markConnected(): void {
+    this.recovering = false
+    this.backoff.reset()
+  }
+
+  private async initialize(): Promise<void> {
+    const attemptGeneration = this.generation
+    const abortController = new AbortController()
+    this.abortController = abortController
+    const isStale = (): boolean =>
+      this.shuttingDown || attemptGeneration !== this.generation
+
+    try {
+      await this.options.initialize({
+        signal: abortController.signal,
+        isStale,
+      })
+      if (isStale()) {
+        await this.options.close().catch(() => undefined)
+        return
+      }
+      this.markConnected()
+    } catch (error) {
+      await this.options.close().catch(() => undefined)
+      if (isStale()) {
+        return
+      }
+      await this.options.onInitializationError(error, this.recovering)
+    } finally {
+      if (this.abortController === abortController) {
+        this.abortController = null
+      }
+    }
+  }
+
+  private queueInitialization(scheduledReconnect = false): Promise<void> {
+    const previous = this.initializationPromise
+    const queuedGeneration = this.generation
+    const startInitialization = (): Promise<void> => {
+      if (scheduledReconnect) {
+        this.reconnectScheduled = false
+      }
+      if (this.shuttingDown || queuedGeneration !== this.generation) {
+        return Promise.resolve()
+      }
+      return this.initialize()
+    }
+    const operation = previous
+      ? previous.catch(() => undefined).then(startInitialization)
+      : startInitialization()
+    this.initializationPromise = operation
+    void operation
+      .finally(() => {
+        if (this.initializationPromise === operation) {
+          this.initializationPromise = null
+        }
+      })
+      .catch(() => undefined)
+    return operation
+  }
+}

--- a/src/amqp-transport-utils.ts
+++ b/src/amqp-transport-utils.ts
@@ -18,7 +18,8 @@ export function routingKeys(
 }
 
 export function parseJson(jsonInput: unknown): JsonValue {
-  return JSON.parse(jsonInput as string) as JsonValue
+  if (typeof jsonInput !== 'string') return jsonInput as JsonValue
+  try { return JSON.parse(jsonInput) as JsonValue } catch { return jsonInput as JsonValue }
 }
 
 export function parseJsonObject(jsonInput: unknown): JsonObject {

--- a/src/amqp-transport-utils.ts
+++ b/src/amqp-transport-utils.ts
@@ -1,0 +1,30 @@
+import { BrokerConfig, JsonObject, JsonValue } from './types'
+
+export function brokerUrl(
+  broker: BrokerConfig,
+  credentials: { username: string; password: string },
+): string {
+  const protocol = broker.tls ? 'amqps' : 'amqp'
+  const vhostPath = broker.vhost ? `/${encodeURIComponent(broker.vhost)}` : '/'
+  return `${protocol}://${encodeURIComponent(credentials.username)}:${encodeURIComponent(credentials.password)}@${broker.host}:${broker.port}${vhostPath}`
+}
+
+export function routingKeys(
+  routingKeyArg: string | undefined,
+  configured: string | undefined,
+  queue: string | undefined,
+): string[] {
+  return (routingKeyArg || configured || queue || '').split(',').map(key => key.trim())
+}
+
+export function parseJson(jsonInput: unknown): JsonValue {
+  return JSON.parse(jsonInput as string) as JsonValue
+}
+
+export function parseJsonObject(jsonInput: unknown): JsonObject {
+  let output: JsonValue
+  try { output = parseJson(jsonInput) } catch { return {} }
+  return typeof output === 'object' && output !== null && !Array.isArray(output)
+    ? output as JsonObject
+    : {}
+}

--- a/src/delivery-settlement-tracker.ts
+++ b/src/delivery-settlement-tracker.ts
@@ -1,0 +1,79 @@
+import { Node } from 'node-red'
+import { Channel } from 'amqplib'
+import { v4 as uuidv4 } from 'uuid'
+import { AssembledMessage } from './types'
+
+export const DELIVERY_TOKEN: unique symbol = Symbol('amqp-delivery-token')
+type TrackedAssembledMessage = AssembledMessage & { [DELIVERY_TOKEN]?: string }
+
+export interface TrackedDelivery {
+  message: AssembledMessage
+  channel: Channel
+  deliveryTag: number
+}
+
+export default class DeliverySettlementTracker {
+  private readonly deliveries = new Map<string, TrackedDelivery>()
+
+  public constructor(private readonly node: Node) {}
+
+  public track(
+    message: AssembledMessage,
+    channel: Channel,
+    manualAck: boolean,
+  ): AssembledMessage {
+    if (!manualAck) return message
+    const token = uuidv4()
+    ;(message as TrackedAssembledMessage)[DELIVERY_TOKEN] = token
+    this.deliveries.set(token, {
+      message,
+      channel,
+      deliveryTag: message.fields.deliveryTag,
+    })
+    return message
+  }
+
+  public resolve(
+    message: AssembledMessage,
+    operation: string,
+    channel: Channel,
+    manualAck: boolean,
+  ): (TrackedDelivery & { token?: string }) | null {
+    if (!manualAck) {
+      return { message, channel, deliveryTag: message.fields?.deliveryTag ?? 0 }
+    }
+    const token = (message as TrackedAssembledMessage)[DELIVERY_TOKEN]
+    const delivery = token ? this.deliveries.get(token) : undefined
+    if (!delivery || delivery.channel !== channel) {
+      this.node.error(
+        `Could not ${operation} message: delivery does not belong to the active AMQP channel`,
+      )
+      return null
+    }
+    return { ...delivery, token }
+  }
+
+  public remove(
+    delivery: TrackedDelivery & { token?: string },
+    allUpTo: boolean,
+    manualAck: boolean,
+  ): void {
+    if (!manualAck) return
+    if (!allUpTo) {
+      if (delivery.token) this.deliveries.delete(delivery.token)
+      return
+    }
+    for (const [token, tracked] of this.deliveries) {
+      if (
+        tracked.channel === delivery.channel &&
+        tracked.deliveryTag <= delivery.deliveryTag
+      ) {
+        this.deliveries.delete(token)
+      }
+    }
+  }
+
+  public clear(): void {
+    this.deliveries.clear()
+  }
+}

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -13,6 +13,7 @@ import {
 } from '../types'
 import Amqp from '../Amqp'
 import ReconnectBackoff from '../reconnect-backoff'
+import trackTerminalClose from './flow-close-tracker'
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
@@ -57,6 +58,7 @@ module.exports = function (RED: NodeRedApp): void {
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
 
     const amqp = new Amqp(RED, this, configAmqp)
+    const terminalClose = trackTerminalClose(RED, this.id)
 
     const reconnectOnError = configAmqp.reconnectOnError;
 
@@ -127,13 +129,15 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
+      const removeBindings = terminalClose.shouldRemoveBindings(removed)
+      terminalClose.dispose()
       isShuttingDown = true
       initializationVersion += 1
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
       try {
-        await amqp.close(removed ? { removeBindings: true } : undefined)
+        await amqp.close(removeBindings ? { removeBindings: true } : undefined)
       } catch (e) {
         closeError = e
       } finally {
@@ -200,13 +204,13 @@ module.exports = function (RED: NodeRedApp): void {
           const reconnectDelayMs = reconnectBackoff.nextDelayMs()
           nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
-            reconnectScheduled = false
             if (isShuttingDown) {
+              reconnectScheduled = false
               nodeIns.log('Reconnect timer fired but node is shutting down')
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns)
+            void queueInitialization(nodeIns, true)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -347,11 +351,17 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
-    function queueInitialization(nodeIns: Node): Promise<void> {
+    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const startInitialization = (): Promise<void> => {
+        if (scheduledReconnect) {
+          reconnectScheduled = false
+        }
+        return initializeNode(nodeIns)
+      }
       const operation = previous
-        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
-        : initializeNode(nodeIns)
+        ? previous.catch(() => undefined).then(startInitialization)
+        : startInitialization()
       initializationPromise = operation
       void operation
         .finally(() => {

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -192,6 +192,9 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         initializationVersion += 1
+        initializationAbortController?.abort(
+          new Error('AMQP initialization cancelled for reconnect'),
+        )
         reconnectScheduled = true
 
         clearTimeout(reconnectTimeout)

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -58,7 +58,7 @@ module.exports = function (RED: NodeRedApp): void {
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
 
     const amqp = new Amqp(RED, this, configAmqp)
-    const terminalClose = trackTerminalClose(RED, this.id)
+    const terminalClose = trackTerminalClose(RED, this)
 
     const reconnectOnError = configAmqp.reconnectOnError;
 

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -35,6 +35,7 @@ module.exports = function (RED: NodeRedApp): void {
     let isShuttingDown = false
     let initializationVersion = 0
     let initializationPromise: Promise<void> | null = null
+    let initializationAbortController: AbortController | null = null
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -133,6 +134,9 @@ module.exports = function (RED: NodeRedApp): void {
       terminalClose.dispose()
       isShuttingDown = true
       initializationVersion += 1
+      initializationAbortController?.abort(
+        new Error('AMQP initialization cancelled during shutdown'),
+      )
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -174,6 +178,8 @@ module.exports = function (RED: NodeRedApp): void {
 
     async function initializeNode(nodeIns: Node) {
       const attemptVersion = initializationVersion
+      const abortController = new AbortController()
+      initializationAbortController = abortController
       const initializationIsStale = (): boolean =>
         isShuttingDown || attemptVersion !== initializationVersion
 
@@ -220,7 +226,7 @@ module.exports = function (RED: NodeRedApp): void {
 
 
       try {
-        connection = await amqp.connect()
+        connection = await amqp.connect({ signal: abortController.signal })
         if (initializationIsStale()) {
           await amqp.close().catch(() => undefined)
           return
@@ -228,7 +234,9 @@ module.exports = function (RED: NodeRedApp): void {
 
         // istanbul ignore else
         if (connection) {
-          channel = await amqp.initialize()
+          channel = await amqp.initialize({
+            signal: abortController.signal,
+          })
           if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
@@ -348,14 +356,22 @@ module.exports = function (RED: NodeRedApp): void {
             nodeIns.status(NODE_STATUS.Error)
           }
         }
+      } finally {
+        if (initializationAbortController === abortController) {
+          initializationAbortController = null
+        }
       }
     }
 
     function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const queuedVersion = initializationVersion
       const startInitialization = (): Promise<void> => {
         if (scheduledReconnect) {
           reconnectScheduled = false
+        }
+        if (isShuttingDown || queuedVersion !== initializationVersion) {
+          return Promise.resolve()
         }
         return initializeNode(nodeIns)
       }

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -133,7 +133,7 @@ module.exports = function (RED: NodeRedApp): void {
       removeEventListeners()
       let closeError: unknown
       try {
-        await amqp.close()
+        await amqp.close(removed ? { removeBindings: true } : undefined)
       } catch (e) {
         closeError = e
       } finally {

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -28,9 +28,12 @@ module.exports = function (RED: NodeRedApp): void {
 
   function AmqpInManualAck(config: EditorNodeProperties): void {
     let reconnectTimeout: NodeJS.Timeout
-    let reconnect: (() => Promise<void>) | null = null
+    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
     let reconnectScheduled = false
+    let recoveringFromDisconnect = false
     let isShuttingDown = false
+    let initializationVersion = 0
+    let initializationPromise: Promise<void> | null = null
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -67,7 +70,13 @@ module.exports = function (RED: NodeRedApp): void {
       done?: (err?: Error) => void,
     ) => {
       // handle manual reconnect control message
-      if (msg.payload && msg.payload.reconnectCall && typeof reconnect === 'function') {
+        const isAmqpDelivery = typeof msg.fields?.deliveryTag === 'number'
+        if (
+            !isAmqpDelivery &&
+            msg.payload &&
+            msg.payload.reconnectCall &&
+            typeof reconnect === 'function'
+        ) {
         try {
           await reconnect()
           done && done()
@@ -78,30 +87,36 @@ module.exports = function (RED: NodeRedApp): void {
       }
 
       const assembledMsg = msg as AssembledMessage
+      let settled: boolean
       // handle manualAck
       if (msg.manualAck) {
         const ackMode = msg.manualAck.ackMode
 
         switch (ackMode) {
           case ManualAckType.AckAll:
-            amqp.ackAll()
+            settled = amqp.ackAll(assembledMsg)
             break
           case ManualAckType.Nack:
-            amqp.nack(assembledMsg)
+            settled = amqp.nack(assembledMsg)
             break
           case ManualAckType.NackAll:
-            amqp.nackAll(assembledMsg)
+            settled = amqp.nackAll(assembledMsg)
             break
           case ManualAckType.Reject:
-            amqp.reject(assembledMsg)
+            settled = amqp.reject(assembledMsg)
             break
           case ManualAckType.Ack:
           default:
-            amqp.ack(assembledMsg)
+            settled = amqp.ack(assembledMsg)
             break
         }
       } else {
-        amqp.ack(assembledMsg)
+        settled = amqp.ack(assembledMsg)
+      }
+
+      if (!settled) {
+        done && done(new Error('Could not settle AMQP message'))
+        return
       }
 
       done && done()
@@ -113,6 +128,7 @@ module.exports = function (RED: NodeRedApp): void {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
+      initializationVersion += 1
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -153,13 +169,19 @@ module.exports = function (RED: NodeRedApp): void {
     }
 
     async function initializeNode(nodeIns: Node) {
-      reconnect = async () => {
+      const attemptVersion = initializationVersion
+      const initializationIsStale = (): boolean =>
+        isShuttingDown || attemptVersion !== initializationVersion
+
+      reconnect = async (continueUntilConnected = false) => {
+        recoveringFromDisconnect ||= continueUntilConnected
         if (isShuttingDown || reconnectScheduled) {
           if (isShuttingDown) {
             nodeIns.log('Reconnect skipped: node is shutting down')
           }
           return
         }
+        initializationVersion += 1
         reconnectScheduled = true
 
         clearTimeout(reconnectTimeout)
@@ -184,7 +206,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns)
+            void queueInitialization(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -195,12 +217,20 @@ module.exports = function (RED: NodeRedApp): void {
 
       try {
         connection = await amqp.connect()
+        if (initializationIsStale()) {
+          await amqp.close().catch(() => undefined)
+          return
+        }
 
         // istanbul ignore else
         if (connection) {
           channel = await amqp.initialize()
+          if (initializationIsStale()) {
+            await amqp.close().catch(() => undefined)
+            return
+          }
           await amqp.consume()
-          if (isShuttingDown) {
+          if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
           }
@@ -208,7 +238,7 @@ module.exports = function (RED: NodeRedApp): void {
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
@@ -232,7 +262,7 @@ module.exports = function (RED: NodeRedApp): void {
           onChannelClose = async () => {
             nodeIns.warn('AMQP channel closed event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -256,7 +286,7 @@ module.exports = function (RED: NodeRedApp): void {
           onConsumerCancelled = async () => {
             nodeIns.warn('AMQP consumer cancelled event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -271,18 +301,22 @@ module.exports = function (RED: NodeRedApp): void {
           nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
 
           amqp.markConnected()
+          recoveringFromDisconnect = false
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
         await amqp.close().catch(() => undefined)
-        if (isShuttingDown) {
+        if (
+          isShuttingDown ||
+          attemptVersion !== initializationVersion
+        ) {
           return
         }
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpInManualAck() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-          if (reconnectOnError) {
+          if (reconnectOnError || recoveringFromDisconnect) {
             let reconnectFailed = false
             await reconnect().catch(reconnectError => {
               reconnectFailed = true
@@ -299,7 +333,7 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.error(`AmqpInManualAck() ${e}`, {
             payload: { error: e, location: ErrorLocationEnum.ConnectError },
           })
-          if (reconnectOnError) {
+          if (reconnectOnError || recoveringFromDisconnect) {
             await reconnect().catch(reconnectError => {
               nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
@@ -313,8 +347,24 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
+    function queueInitialization(nodeIns: Node): Promise<void> {
+      const previous = initializationPromise
+      const operation = previous
+        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
+        : initializeNode(nodeIns)
+      initializationPromise = operation
+      void operation
+        .finally(() => {
+          if (initializationPromise === operation) {
+            initializationPromise = null
+          }
+        })
+        .catch(() => undefined)
+      return operation
+    }
+
     // call
-    initializeNode(this);
+    void queueInitialization(this)
   }
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -1,35 +1,19 @@
 import { NodeRedApp, EditorNodeProperties, NodeMessageInFlow } from 'node-red'
-import { Channel, ChannelModel } from 'amqplib'
 import { NODE_STATUS } from '../constants'
 import {
-  ErrorType,
   NodeType,
   ManualAckType,
   ManualAckFields,
   AmqpOutNodeDefaults,
   AmqpInNodeDefaults,
-  ErrorLocationEnum,
   AssembledMessage,
 } from '../types'
 import Amqp from '../Amqp'
-import AmqpLifecycleCoordinator, {
-  LifecycleAttempt,
-} from '../amqp-lifecycle-coordinator'
-import trackTerminalClose from './flow-close-tracker'
+import createAmqpInputLifecycle from './amqp-input-lifecycle'
 
 module.exports = function (RED: NodeRedApp): void {
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
-  const isInvalidLoginError = (value: unknown): boolean => {
-    const error =
-      typeof value === 'object' && value !== null
-        ? (value as { code?: string; message?: string })
-        : {}
-    return (
-      error.code === ErrorType.InvalidLogin ||
-      /ACCESS_REFUSED/i.test(error.message || '')
-    )
-  }
 
   function AmqpInManualAck(config: EditorNodeProperties): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -40,258 +24,58 @@ module.exports = function (RED: NodeRedApp): void {
     const node = this
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config
     const amqp = new Amqp(RED, node, configAmqp)
-    const terminalClose = trackTerminalClose(RED, node)
-    const reconnectOnError = configAmqp.reconnectOnError
-    const nodeEmitter = node as unknown as {
-      on?: (event: string, listener: (...args: unknown[]) => void) => void
-      off?: (event: string, listener: (...args: unknown[]) => void) => void
-    }
-    let connection: ChannelModel | null = null
-    let channel: Channel | null = null
-    let onConnClose: () => Promise<void>
-    let onConnError: (error: unknown) => Promise<void>
-    let onChannelClose: () => Promise<void>
-    let onChannelError: (error: unknown) => Promise<void>
-    let onConsumerCancelled: () => Promise<void>
-    let lifecycle: AmqpLifecycleCoordinator
-
-    const removeEventListeners = (): void => {
-      if (typeof onConnClose === 'function') {
-        connection?.off?.('close', onConnClose)
-      }
-      if (typeof onConnError === 'function') {
-        connection?.off?.('error', onConnError)
-      }
-      if (typeof onChannelClose === 'function') {
-        channel?.off?.('close', onChannelClose)
-      }
-      if (typeof onChannelError === 'function') {
-        channel?.off?.('error', onChannelError)
-      }
-      if (typeof onConsumerCancelled === 'function') {
-        nodeEmitter.off?.('amqp:consumer-cancelled', onConsumerCancelled)
-      }
-    }
-
-    const reportReconnectFailure = (
-      message: string,
-      error: unknown,
-      location: ErrorLocationEnum,
-    ): void => {
-      node.error(`${message}: ${error}`, {
-        payload: { error, location },
-      })
-    }
-
-    const setupEventListeners = (): void => {
-      onConnClose = async () => {
-        node.warn('AMQP connection closed event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after connection close',
-              error,
-              ErrorLocationEnum.ConnectionErrorEvent,
-            ),
-          )
-      }
-      onConnError = async error => {
-        if (reconnectOnError) {
-          await lifecycle
-            .reconnect()
-            .catch(reconnectError =>
-              reportReconnectFailure(
-                'Reconnect failed after connection error',
-                reconnectError,
-                ErrorLocationEnum.ConnectionErrorEvent,
-              ),
-            )
-        }
-        node.error(`Connection error ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectionErrorEvent },
-        })
-      }
-      onChannelClose = async () => {
-        node.warn('AMQP channel closed event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after channel close',
-              error,
-              ErrorLocationEnum.ChannelErrorEvent,
-            ),
-          )
-      }
-      onChannelError = async error => {
-        if (reconnectOnError) {
-          await lifecycle
-            .reconnect()
-            .catch(reconnectError =>
-              reportReconnectFailure(
-                'Reconnect failed after channel error',
-                reconnectError,
-                ErrorLocationEnum.ChannelErrorEvent,
-              ),
-            )
-        }
-        node.error(`Channel error ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ChannelErrorEvent },
-        })
-      }
-      onConsumerCancelled = async () => {
-        node.warn('AMQP consumer cancelled event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after consumer cancellation',
-              error,
-              ErrorLocationEnum.ChannelErrorEvent,
-            ),
-          )
-      }
-      connection?.on('close', onConnClose)
-      connection?.on('error', onConnError)
-      channel?.on('close', onChannelClose)
-      channel?.on('error', onChannelError)
-      nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
-    }
-
-    const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
-      connection = await amqp.connect({ signal: attempt.signal })
-      if (attempt.isStale()) return
-      channel = await amqp.initialize({ signal: attempt.signal })
-      if (attempt.isStale()) return
-      await amqp.consume()
-      if (attempt.isStale()) return
-      setupEventListeners()
-      amqp.markConnected()
-    }
-
-    const onInitializationError = async (
-      error: unknown,
-      recovering: boolean,
-    ): Promise<void> => {
-      const invalidLogin = isInvalidLoginError(error)
-      if (invalidLogin) {
-        node.status(NODE_STATUS.Invalid)
-        node.error(`AmqpInManualAck() Could not connect to broker ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectError },
-        })
-      } else {
-        node.error(`AmqpInManualAck() ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectError },
-        })
-      }
-
-      if (reconnectOnError || recovering) {
-        let reconnectFailed = false
-        await lifecycle.reconnect().catch(reconnectError => {
-          reconnectFailed = true
-          node.status(NODE_STATUS.Error)
-          reportReconnectFailure(
-            'Reconnect failed during initialization',
-            reconnectError,
-            ErrorLocationEnum.ConnectError,
-          )
-        })
-        if (invalidLogin && !reconnectFailed) {
-          node.status(NODE_STATUS.Invalid)
-        }
-      } else if (!invalidLogin) {
-        node.status(NODE_STATUS.Error)
-      }
-    }
-
-    lifecycle = new AmqpLifecycleCoordinator({
+    createAmqpInputLifecycle({
+      RED,
       node,
-      initialize,
-      close: () => amqp.close(),
-      removeEventListeners,
-      clearResources: () => {
-        connection = null
-        channel = null
-      },
-      onInitializationError,
-    })
+      config: configAmqp,
+      amqp,
+      nodeName: 'AmqpInManualAck()',
+      registerInput: lifecycle => {
+        node.on(
+          'input',
+          async (
+            msg: NodeMessageInFlow &
+              Partial<AssembledMessage> & {
+                manualAck?: ManualAckFields
+                payload?: { reconnectCall?: boolean }
+              },
+            _: unknown,
+            done?: (error?: Error) => void,
+          ) => {
+            const isAmqpDelivery = typeof msg.fields?.deliveryTag === 'number'
+            if (!isAmqpDelivery && msg.payload?.reconnectCall) {
+              await lifecycle
+                .reconnect()
+                .then(() => done?.())
+                .catch(error => done?.(toError(error)))
+              return
+            }
 
-    node.on(
-      'input',
-      async (
-        msg: NodeMessageInFlow &
-          Partial<AssembledMessage> & {
-            manualAck?: ManualAckFields
-            payload?: { reconnectCall?: boolean }
+            const assembledMessage = msg as AssembledMessage
+            let settled: boolean
+            switch (msg.manualAck?.ackMode) {
+              case ManualAckType.AckAll:
+                settled = amqp.ackAll(assembledMessage)
+                break
+              case ManualAckType.Nack:
+                settled = amqp.nack(assembledMessage)
+                break
+              case ManualAckType.NackAll:
+                settled = amqp.nackAll(assembledMessage)
+                break
+              case ManualAckType.Reject:
+                settled = amqp.reject(assembledMessage)
+                break
+              case ManualAckType.Ack:
+              default:
+                settled = amqp.ack(assembledMessage)
+                break
+            }
+            done?.(settled ? undefined : new Error('Could not settle AMQP message'))
           },
-        _: unknown,
-        done?: (error?: Error) => void,
-      ) => {
-        const isAmqpDelivery = typeof msg.fields?.deliveryTag === 'number'
-        if (!isAmqpDelivery && msg.payload?.reconnectCall) {
-          await lifecycle
-            .reconnect()
-            .then(() => done?.())
-            .catch(error => done?.(toError(error)))
-          return
-        }
-
-        const assembledMessage = msg as AssembledMessage
-        let settled: boolean
-        switch (msg.manualAck?.ackMode) {
-          case ManualAckType.AckAll:
-            settled = amqp.ackAll(assembledMessage)
-            break
-          case ManualAckType.Nack:
-            settled = amqp.nack(assembledMessage)
-            break
-          case ManualAckType.NackAll:
-            settled = amqp.nackAll(assembledMessage)
-            break
-          case ManualAckType.Reject:
-            settled = amqp.reject(assembledMessage)
-            break
-          case ManualAckType.Ack:
-          default:
-            settled = amqp.ack(assembledMessage)
-            break
-        }
-        done?.(settled ? undefined : new Error('Could not settle AMQP message'))
-      },
-    )
-
-    node.on(
-      'close',
-      async (
-        removedOrDone: boolean | ((error?: Error) => void),
-        doneMaybe?: (error?: Error) => void,
-      ): Promise<void> => {
-        const removed =
-          typeof removedOrDone === 'boolean' ? removedOrDone : false
-        const done =
-          typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
-        const removeBindings = terminalClose.shouldRemoveBindings(removed)
-        terminalClose.dispose()
-        lifecycle.shutdown(
-          new Error('AMQP initialization cancelled during shutdown'),
         )
-        try {
-          await amqp.close(
-            removeBindings ? { removeBindings: true } : undefined,
-          )
-          done?.()
-        } catch (error) {
-          done?.(toError(error))
-        } finally {
-          if (removed) {
-            amqp.removeBrokerNodeState()
-          }
-        }
       },
-    )
-
-    void lifecycle.start()
+    })
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/nodes/amqp-in-manual-ack.ts
+++ b/src/nodes/amqp-in-manual-ack.ts
@@ -1,4 +1,4 @@
-import { NodeRedApp, EditorNodeProperties, Node, NodeMessageInFlow } from 'node-red'
+import { NodeRedApp, EditorNodeProperties, NodeMessageInFlow } from 'node-red'
 import { Channel, ChannelModel } from 'amqplib'
 import { NODE_STATUS } from '../constants'
 import {
@@ -12,151 +12,48 @@ import {
   AssembledMessage,
 } from '../types'
 import Amqp from '../Amqp'
-import ReconnectBackoff from '../reconnect-backoff'
+import AmqpLifecycleCoordinator, {
+  LifecycleAttempt,
+} from '../amqp-lifecycle-coordinator'
 import trackTerminalClose from './flow-close-tracker'
 
 module.exports = function (RED: NodeRedApp): void {
-  const isErrorLike = (
-    value: unknown,
-  ): value is { code?: string; message?: string; isOperational?: boolean } =>
-    typeof value === 'object' && value !== null
-  const isInvalidLoginError = (
-    err: { code?: string; message?: string },
-  ): boolean =>
-    err.code === ErrorType.InvalidLogin || /ACCESS_REFUSED/i.test(err.message || '')
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
+  const isInvalidLoginError = (value: unknown): boolean => {
+    const error =
+      typeof value === 'object' && value !== null
+        ? (value as { code?: string; message?: string })
+        : {}
+    return (
+      error.code === ErrorType.InvalidLogin ||
+      /ACCESS_REFUSED/i.test(error.message || '')
+    )
+  }
 
   function AmqpInManualAck(config: EditorNodeProperties): void {
-    let reconnectTimeout: NodeJS.Timeout
-    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
-    let reconnectScheduled = false
-    let recoveringFromDisconnect = false
-    let isShuttingDown = false
-    let initializationVersion = 0
-    let initializationPromise: Promise<void> | null = null
-    let initializationAbortController: AbortController | null = null
-    let connection: ChannelModel | null = null
-    let channel: Channel | null = null
-    let onConnClose: (e: unknown) => Promise<void>
-    let onConnError: (e: unknown) => Promise<void>
-    let onChannelClose: () => Promise<void>
-    let onChannelError: (e: unknown) => Promise<void>
-    let onConsumerCancelled: () => Promise<void>
-    const me = this
-    const reconnectBackoff = new ReconnectBackoff()
-    const nodeEmitter = me as unknown as {
-      on?: (event: string, listener: (...args: unknown[]) => void) => void
-      off?: (event: string, listener: (...args: unknown[]) => void) => void
-    }
-
-
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     RED.nodes.createNode(this, config)
     this.status(NODE_STATUS.Disconnected)
 
-    const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
-
-    const amqp = new Amqp(RED, this, configAmqp)
-    const terminalClose = trackTerminalClose(RED, this)
-
-    const reconnectOnError = configAmqp.reconnectOnError;
-
-    const inputListener = async (
-      msg: NodeMessageInFlow &
-        Partial<AssembledMessage> & {
-          manualAck?: ManualAckFields
-          payload?: { reconnectCall?: boolean }
-        },
-      _: unknown,
-      done?: (err?: Error) => void,
-    ) => {
-      // handle manual reconnect control message
-        const isAmqpDelivery = typeof msg.fields?.deliveryTag === 'number'
-        if (
-            !isAmqpDelivery &&
-            msg.payload &&
-            msg.payload.reconnectCall &&
-            typeof reconnect === 'function'
-        ) {
-        try {
-          await reconnect()
-          done && done()
-        } catch (e) {
-          done && done(toError(e))
-        }
-        return
-      }
-
-      const assembledMsg = msg as AssembledMessage
-      let settled: boolean
-      // handle manualAck
-      if (msg.manualAck) {
-        const ackMode = msg.manualAck.ackMode
-
-        switch (ackMode) {
-          case ManualAckType.AckAll:
-            settled = amqp.ackAll(assembledMsg)
-            break
-          case ManualAckType.Nack:
-            settled = amqp.nack(assembledMsg)
-            break
-          case ManualAckType.NackAll:
-            settled = amqp.nackAll(assembledMsg)
-            break
-          case ManualAckType.Reject:
-            settled = amqp.reject(assembledMsg)
-            break
-          case ManualAckType.Ack:
-          default:
-            settled = amqp.ack(assembledMsg)
-            break
-        }
-      } else {
-        settled = amqp.ack(assembledMsg)
-      }
-
-      if (!settled) {
-        done && done(new Error('Could not settle AMQP message'))
-        return
-      }
-
-      done && done()
+    const node = this
+    const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config
+    const amqp = new Amqp(RED, node, configAmqp)
+    const terminalClose = trackTerminalClose(RED, node)
+    const reconnectOnError = configAmqp.reconnectOnError
+    const nodeEmitter = node as unknown as {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void
+      off?: (event: string, listener: (...args: unknown[]) => void) => void
     }
-    // receive input reconnectCall
-    this.on('input', inputListener)
-    // When the server goes down
-    this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
-      const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
-      const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
-      const removeBindings = terminalClose.shouldRemoveBindings(removed)
-      terminalClose.dispose()
-      isShuttingDown = true
-      initializationVersion += 1
-      initializationAbortController?.abort(
-        new Error('AMQP initialization cancelled during shutdown'),
-      )
-      clearTimeout(reconnectTimeout)
-      removeEventListeners()
-      let closeError: unknown
-      try {
-        await amqp.close(removeBindings ? { removeBindings: true } : undefined)
-      } catch (e) {
-        closeError = e
-      } finally {
-        if (removed) {
-          amqp.removeBrokerNodeState()
-        }
-      }
-
-      if (closeError) {
-        done && done(toError(closeError))
-        return
-      }
-
-      done && done()
-    })
+    let connection: ChannelModel | null = null
+    let channel: Channel | null = null
+    let onConnClose: () => Promise<void>
+    let onConnError: (error: unknown) => Promise<void>
+    let onChannelClose: () => Promise<void>
+    let onChannelError: (error: unknown) => Promise<void>
+    let onConsumerCancelled: () => Promise<void>
+    let lifecycle: AmqpLifecycleCoordinator
 
     const removeEventListeners = (): void => {
       if (typeof onConnClose === 'function') {
@@ -176,225 +73,227 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
-    async function initializeNode(nodeIns: Node) {
-      const attemptVersion = initializationVersion
-      const abortController = new AbortController()
-      initializationAbortController = abortController
-      const initializationIsStale = (): boolean =>
-        isShuttingDown || attemptVersion !== initializationVersion
-
-      reconnect = async (continueUntilConnected = false) => {
-        recoveringFromDisconnect ||= continueUntilConnected
-        if (isShuttingDown || reconnectScheduled) {
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect skipped: node is shutting down')
-          }
-          return
-        }
-        initializationVersion += 1
-        initializationAbortController?.abort(
-          new Error('AMQP initialization cancelled for reconnect'),
-        )
-        reconnectScheduled = true
-
-        clearTimeout(reconnectTimeout)
-        try {
-          nodeIns.log('Reconnect requested: closing AMQP resources')
-          removeEventListeners()
-          await amqp.close()
-          if (isShuttingDown) {
-            reconnectScheduled = false
-            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
-            return
-          }
-          channel = null
-          connection = null
-
-          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
-          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
-          reconnectTimeout = setTimeout(() => {
-            if (isShuttingDown) {
-              reconnectScheduled = false
-              nodeIns.log('Reconnect timer fired but node is shutting down')
-              return
-            }
-            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns, true)
-          }, reconnectDelayMs)
-        } catch (error) {
-          reconnectScheduled = false
-          throw error
-        }
-      }
-
-
-      try {
-        connection = await amqp.connect({ signal: abortController.signal })
-        if (initializationIsStale()) {
-          await amqp.close().catch(() => undefined)
-          return
-        }
-
-        // istanbul ignore else
-        if (connection) {
-          channel = await amqp.initialize({
-            signal: abortController.signal,
-          })
-          if (initializationIsStale()) {
-            await amqp.close().catch(() => undefined)
-            return
-          }
-          await amqp.consume()
-          if (initializationIsStale()) {
-            await amqp.close().catch(() => undefined)
-            return
-          }
-
-          onConnClose = async () => {
-            nodeIns.warn('AMQP connection closed event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
-              })
-            }
-          }
-
-          onConnError = async e => {
-            if (reconnectOnError) {
-              try {
-                await reconnect()
-              } catch (reconnectError) {
-                nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
-                  payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
-                })
-              }
-            }
-            nodeIns.error(`Connection error ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectionErrorEvent } })
-          }
-
-          onChannelClose = async () => {
-            nodeIns.warn('AMQP channel closed event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-              })
-            }
-          }
-
-          onChannelError = async e => {
-            if (reconnectOnError) {
-              try {
-                await reconnect()
-              } catch (reconnectError) {
-                nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
-                  payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-                })
-              }
-            }
-            nodeIns.error(`Channel error ${e}`, { payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent } })
-          }
-
-          onConsumerCancelled = async () => {
-            nodeIns.warn('AMQP consumer cancelled event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-              })
-            }
-          }
-
-          connection.on('close', onConnClose)
-          connection.on('error', onConnError)
-          channel.on('close', onChannelClose)
-          channel.on('error', onChannelError)
-          nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
-
-          amqp.markConnected()
-          recoveringFromDisconnect = false
-          reconnectBackoff.reset()
-        }
-      } catch (e: unknown) {
-        await amqp.close().catch(() => undefined)
-        if (
-          isShuttingDown ||
-          attemptVersion !== initializationVersion
-        ) {
-          return
-        }
-        const err = isErrorLike(e) ? e : {}
-        if (isInvalidLoginError(err)) {
-          nodeIns.status(NODE_STATUS.Invalid)
-          nodeIns.error(`AmqpInManualAck() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-          if (reconnectOnError || recoveringFromDisconnect) {
-            let reconnectFailed = false
-            await reconnect().catch(reconnectError => {
-              reconnectFailed = true
-              nodeIns.status(NODE_STATUS.Error)
-              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
-              })
-            })
-            if (!reconnectFailed) {
-              nodeIns.status(NODE_STATUS.Invalid)
-            }
-          }
-        } else {
-          nodeIns.error(`AmqpInManualAck() ${e}`, {
-            payload: { error: e, location: ErrorLocationEnum.ConnectError },
-          })
-          if (reconnectOnError || recoveringFromDisconnect) {
-            await reconnect().catch(reconnectError => {
-              nodeIns.status(NODE_STATUS.Error)
-              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
-              })
-            })
-          } else {
-            nodeIns.status(NODE_STATUS.Error)
-          }
-        }
-      } finally {
-        if (initializationAbortController === abortController) {
-          initializationAbortController = null
-        }
-      }
+    const reportReconnectFailure = (
+      message: string,
+      error: unknown,
+      location: ErrorLocationEnum,
+    ): void => {
+      node.error(`${message}: ${error}`, {
+        payload: { error, location },
+      })
     }
 
-    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
-      const previous = initializationPromise
-      const queuedVersion = initializationVersion
-      const startInitialization = (): Promise<void> => {
-        if (scheduledReconnect) {
-          reconnectScheduled = false
-        }
-        if (isShuttingDown || queuedVersion !== initializationVersion) {
-          return Promise.resolve()
-        }
-        return initializeNode(nodeIns)
+    const setupEventListeners = (): void => {
+      onConnClose = async () => {
+        node.warn('AMQP connection closed event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after connection close',
+              error,
+              ErrorLocationEnum.ConnectionErrorEvent,
+            ),
+          )
       }
-      const operation = previous
-        ? previous.catch(() => undefined).then(startInitialization)
-        : startInitialization()
-      initializationPromise = operation
-      void operation
-        .finally(() => {
-          if (initializationPromise === operation) {
-            initializationPromise = null
-          }
+      onConnError = async error => {
+        if (reconnectOnError) {
+          await lifecycle
+            .reconnect()
+            .catch(reconnectError =>
+              reportReconnectFailure(
+                'Reconnect failed after connection error',
+                reconnectError,
+                ErrorLocationEnum.ConnectionErrorEvent,
+              ),
+            )
+        }
+        node.error(`Connection error ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectionErrorEvent },
         })
-        .catch(() => undefined)
-      return operation
+      }
+      onChannelClose = async () => {
+        node.warn('AMQP channel closed event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after channel close',
+              error,
+              ErrorLocationEnum.ChannelErrorEvent,
+            ),
+          )
+      }
+      onChannelError = async error => {
+        if (reconnectOnError) {
+          await lifecycle
+            .reconnect()
+            .catch(reconnectError =>
+              reportReconnectFailure(
+                'Reconnect failed after channel error',
+                reconnectError,
+                ErrorLocationEnum.ChannelErrorEvent,
+              ),
+            )
+        }
+        node.error(`Channel error ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ChannelErrorEvent },
+        })
+      }
+      onConsumerCancelled = async () => {
+        node.warn('AMQP consumer cancelled event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after consumer cancellation',
+              error,
+              ErrorLocationEnum.ChannelErrorEvent,
+            ),
+          )
+      }
+      connection?.on('close', onConnClose)
+      connection?.on('error', onConnError)
+      channel?.on('close', onChannelClose)
+      channel?.on('error', onChannelError)
+      nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
     }
 
-    // call
-    void queueInitialization(this)
+    const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
+      connection = await amqp.connect({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      channel = await amqp.initialize({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      await amqp.consume()
+      if (attempt.isStale()) return
+      setupEventListeners()
+      amqp.markConnected()
+    }
+
+    const onInitializationError = async (
+      error: unknown,
+      recovering: boolean,
+    ): Promise<void> => {
+      const invalidLogin = isInvalidLoginError(error)
+      if (invalidLogin) {
+        node.status(NODE_STATUS.Invalid)
+        node.error(`AmqpInManualAck() Could not connect to broker ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      } else {
+        node.error(`AmqpInManualAck() ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      }
+
+      if (reconnectOnError || recovering) {
+        let reconnectFailed = false
+        await lifecycle.reconnect().catch(reconnectError => {
+          reconnectFailed = true
+          node.status(NODE_STATUS.Error)
+          reportReconnectFailure(
+            'Reconnect failed during initialization',
+            reconnectError,
+            ErrorLocationEnum.ConnectError,
+          )
+        })
+        if (invalidLogin && !reconnectFailed) {
+          node.status(NODE_STATUS.Invalid)
+        }
+      } else if (!invalidLogin) {
+        node.status(NODE_STATUS.Error)
+      }
+    }
+
+    lifecycle = new AmqpLifecycleCoordinator({
+      node,
+      initialize,
+      close: () => amqp.close(),
+      removeEventListeners,
+      clearResources: () => {
+        connection = null
+        channel = null
+      },
+      onInitializationError,
+    })
+
+    node.on(
+      'input',
+      async (
+        msg: NodeMessageInFlow &
+          Partial<AssembledMessage> & {
+            manualAck?: ManualAckFields
+            payload?: { reconnectCall?: boolean }
+          },
+        _: unknown,
+        done?: (error?: Error) => void,
+      ) => {
+        const isAmqpDelivery = typeof msg.fields?.deliveryTag === 'number'
+        if (!isAmqpDelivery && msg.payload?.reconnectCall) {
+          await lifecycle
+            .reconnect()
+            .then(() => done?.())
+            .catch(error => done?.(toError(error)))
+          return
+        }
+
+        const assembledMessage = msg as AssembledMessage
+        let settled: boolean
+        switch (msg.manualAck?.ackMode) {
+          case ManualAckType.AckAll:
+            settled = amqp.ackAll(assembledMessage)
+            break
+          case ManualAckType.Nack:
+            settled = amqp.nack(assembledMessage)
+            break
+          case ManualAckType.NackAll:
+            settled = amqp.nackAll(assembledMessage)
+            break
+          case ManualAckType.Reject:
+            settled = amqp.reject(assembledMessage)
+            break
+          case ManualAckType.Ack:
+          default:
+            settled = amqp.ack(assembledMessage)
+            break
+        }
+        done?.(settled ? undefined : new Error('Could not settle AMQP message'))
+      },
+    )
+
+    node.on(
+      'close',
+      async (
+        removedOrDone: boolean | ((error?: Error) => void),
+        doneMaybe?: (error?: Error) => void,
+      ): Promise<void> => {
+        const removed =
+          typeof removedOrDone === 'boolean' ? removedOrDone : false
+        const done =
+          typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
+        const removeBindings = terminalClose.shouldRemoveBindings(removed)
+        terminalClose.dispose()
+        lifecycle.shutdown(
+          new Error('AMQP initialization cancelled during shutdown'),
+        )
+        try {
+          await amqp.close(
+            removeBindings ? { removeBindings: true } : undefined,
+          )
+          done?.()
+        } catch (error) {
+          done?.(toError(error))
+        } finally {
+          if (removed) {
+            amqp.removeBrokerNodeState()
+          }
+        }
+      },
+    )
+
+    void lifecycle.start()
   }
+
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   RED.nodes.registerType(NodeType.AmqpInManualAck, AmqpInManualAck)

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -80,7 +80,7 @@ module.exports = function (RED: NodeRedApp): void {
       removeEventListeners()
       let closeError: unknown
       try {
-        await amqp.close()
+        await amqp.close(removed ? { removeBindings: true } : undefined)
       } catch (e) {
         closeError = e
       } finally {

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -19,9 +19,12 @@ module.exports = function (RED: NodeRedApp): void {
 
   function AmqpIn(config: EditorNodeProperties): void {
     let reconnectTimeout: NodeJS.Timeout
-    let reconnect: (() => Promise<void>) | null = null
+    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
     let reconnectScheduled = false
+    let recoveringFromDisconnect = false
     let isShuttingDown = false
+    let initializationVersion = 0
+    let initializationPromise: Promise<void> | null = null
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -72,6 +75,7 @@ module.exports = function (RED: NodeRedApp): void {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
+      initializationVersion += 1
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -113,13 +117,19 @@ module.exports = function (RED: NodeRedApp): void {
     }
 
     async function initializeNode(nodeIns: Node) {
-      reconnect = async () => {
+      const attemptVersion = initializationVersion
+      const initializationIsStale = (): boolean =>
+        isShuttingDown || attemptVersion !== initializationVersion
+
+      reconnect = async (continueUntilConnected = false) => {
+        recoveringFromDisconnect ||= continueUntilConnected
         if (isShuttingDown || reconnectScheduled) {
           if (isShuttingDown) {
             nodeIns.log('Reconnect skipped: node is shutting down')
           }
           return
         }
+        initializationVersion += 1
         reconnectScheduled = true
         clearTimeout(reconnectTimeout)
         try {
@@ -143,7 +153,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns)
+            void queueInitialization(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -153,12 +163,20 @@ module.exports = function (RED: NodeRedApp): void {
 
       try {
         connection = await amqp.connect()
+        if (initializationIsStale()) {
+          await amqp.close().catch(() => undefined)
+          return
+        }
 
         // istanbul ignore else
         if (connection) {
           channel = await amqp.initialize()
+          if (initializationIsStale()) {
+            await amqp.close().catch(() => undefined)
+            return
+          }
           await amqp.consume()
-          if (isShuttingDown) {
+          if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
           }
@@ -166,7 +184,7 @@ module.exports = function (RED: NodeRedApp): void {
           onConnClose = async () => {
             nodeIns.warn('AMQP connection closed event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
@@ -192,7 +210,7 @@ module.exports = function (RED: NodeRedApp): void {
           onChannelClose = async () => {
             nodeIns.warn('AMQP channel closed event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -218,7 +236,7 @@ module.exports = function (RED: NodeRedApp): void {
           onConsumerCancelled = async () => {
             nodeIns.warn('AMQP consumer cancelled event received')
             try {
-              await reconnect()
+              await reconnect(true)
             } catch (reconnectError) {
               nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
                 payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -233,18 +251,22 @@ module.exports = function (RED: NodeRedApp): void {
           nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
 
           amqp.markConnected()
+          recoveringFromDisconnect = false
           reconnectBackoff.reset()
         }
       } catch (e: unknown) {
         await amqp.close().catch(() => undefined)
-        if (isShuttingDown) {
+        if (
+          isShuttingDown ||
+          attemptVersion !== initializationVersion
+        ) {
           return
         }
         const err = isErrorLike(e) ? e : {}
         if (isInvalidLoginError(err)) {
           nodeIns.status(NODE_STATUS.Invalid)
           nodeIns.error(`AmqpIn() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-          if (reconnectOnError) {
+          if (reconnectOnError || recoveringFromDisconnect) {
             let reconnectFailed = false
             await reconnect().catch(reconnectError => {
               reconnectFailed = true
@@ -261,7 +283,7 @@ module.exports = function (RED: NodeRedApp): void {
           nodeIns.error(`AmqpIn() ${e}`, {
             payload: { error: e, location: ErrorLocationEnum.ConnectError },
           })
-          if (reconnectOnError) {
+          if (reconnectOnError || recoveringFromDisconnect) {
             await reconnect().catch(reconnectError => {
               nodeIns.status(NODE_STATUS.Error)
               nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
@@ -275,8 +297,24 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
+    function queueInitialization(nodeIns: Node): Promise<void> {
+      const previous = initializationPromise
+      const operation = previous
+        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
+        : initializeNode(nodeIns)
+      initializationPromise = operation
+      void operation
+        .finally(() => {
+          if (initializationPromise === operation) {
+            initializationPromise = null
+          }
+        })
+        .catch(() => undefined)
+      return operation
+    }
+
     // call
-    initializeNode(this);
+    void queueInitialization(this)
   }
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -26,6 +26,7 @@ module.exports = function (RED: NodeRedApp): void {
     let isShuttingDown = false
     let initializationVersion = 0
     let initializationPromise: Promise<void> | null = null
+    let initializationAbortController: AbortController | null = null
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -80,6 +81,9 @@ module.exports = function (RED: NodeRedApp): void {
       terminalClose.dispose()
       isShuttingDown = true
       initializationVersion += 1
+      initializationAbortController?.abort(
+        new Error('AMQP initialization cancelled during shutdown'),
+      )
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -122,6 +126,8 @@ module.exports = function (RED: NodeRedApp): void {
 
     async function initializeNode(nodeIns: Node) {
       const attemptVersion = initializationVersion
+      const abortController = new AbortController()
+      initializationAbortController = abortController
       const initializationIsStale = (): boolean =>
         isShuttingDown || attemptVersion !== initializationVersion
 
@@ -166,7 +172,7 @@ module.exports = function (RED: NodeRedApp): void {
       }
 
       try {
-        connection = await amqp.connect()
+        connection = await amqp.connect({ signal: abortController.signal })
         if (initializationIsStale()) {
           await amqp.close().catch(() => undefined)
           return
@@ -174,7 +180,9 @@ module.exports = function (RED: NodeRedApp): void {
 
         // istanbul ignore else
         if (connection) {
-          channel = await amqp.initialize()
+          channel = await amqp.initialize({
+            signal: abortController.signal,
+          })
           if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
@@ -298,14 +306,22 @@ module.exports = function (RED: NodeRedApp): void {
             nodeIns.status(NODE_STATUS.Error)
           }
         }
+      } finally {
+        if (initializationAbortController === abortController) {
+          initializationAbortController = null
+        }
       }
     }
 
     function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const queuedVersion = initializationVersion
       const startInitialization = (): Promise<void> => {
         if (scheduledReconnect) {
           reconnectScheduled = false
+        }
+        if (isShuttingDown || queuedVersion !== initializationVersion) {
+          return Promise.resolve()
         }
         return initializeNode(nodeIns)
       }

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -49,7 +49,7 @@ module.exports = function (RED: NodeRedApp): void {
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
 
     const amqp = new Amqp(RED, this, configAmqp)
-    const terminalClose = trackTerminalClose(RED, this.id)
+    const terminalClose = trackTerminalClose(RED, this)
 
     const reconnectOnError = configAmqp.reconnectOnError;
 

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -140,6 +140,9 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         initializationVersion += 1
+        initializationAbortController?.abort(
+          new Error('AMQP initialization cancelled for reconnect'),
+        )
         reconnectScheduled = true
         clearTimeout(reconnectTimeout)
         try {

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -4,6 +4,7 @@ import { NODE_STATUS } from '../constants'
 import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorType, NodeType, ErrorLocationEnum } from '../types'
 import Amqp from '../Amqp'
 import ReconnectBackoff from '../reconnect-backoff'
+import trackTerminalClose from './flow-close-tracker'
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
@@ -48,6 +49,7 @@ module.exports = function (RED: NodeRedApp): void {
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
 
     const amqp = new Amqp(RED, this, configAmqp)
+    const terminalClose = trackTerminalClose(RED, this.id)
 
     const reconnectOnError = configAmqp.reconnectOnError;
 
@@ -74,13 +76,15 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
+      const removeBindings = terminalClose.shouldRemoveBindings(removed)
+      terminalClose.dispose()
       isShuttingDown = true
       initializationVersion += 1
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
       try {
-        await amqp.close(removed ? { removeBindings: true } : undefined)
+        await amqp.close(removeBindings ? { removeBindings: true } : undefined)
       } catch (e) {
         closeError = e
       } finally {
@@ -147,13 +151,13 @@ module.exports = function (RED: NodeRedApp): void {
           const reconnectDelayMs = reconnectBackoff.nextDelayMs()
           nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
-            reconnectScheduled = false
             if (isShuttingDown) {
+              reconnectScheduled = false
               nodeIns.log('Reconnect timer fired but node is shutting down')
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns)
+            void queueInitialization(nodeIns, true)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -297,11 +301,17 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
-    function queueInitialization(nodeIns: Node): Promise<void> {
+    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const startInitialization = (): Promise<void> => {
+        if (scheduledReconnect) {
+          reconnectScheduled = false
+        }
+        return initializeNode(nodeIns)
+      }
       const operation = previous
-        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
-        : initializeNode(nodeIns)
+        ? previous.catch(() => undefined).then(startInitialization)
+        : startInitialization()
       initializationPromise = operation
       void operation
         .finally(() => {

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -1,110 +1,56 @@
-import { NodeRedApp, EditorNodeProperties, Node, NodeMessageInFlow } from 'node-red'
+import { NodeRedApp, EditorNodeProperties, NodeMessageInFlow } from 'node-red'
 import { Channel, ChannelModel } from 'amqplib'
 import { NODE_STATUS } from '../constants'
-import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorType, NodeType, ErrorLocationEnum } from '../types'
+import {
+  AmqpInNodeDefaults,
+  AmqpOutNodeDefaults,
+  ErrorType,
+  NodeType,
+  ErrorLocationEnum,
+} from '../types'
 import Amqp from '../Amqp'
-import ReconnectBackoff from '../reconnect-backoff'
+import AmqpLifecycleCoordinator, {
+  LifecycleAttempt,
+} from '../amqp-lifecycle-coordinator'
 import trackTerminalClose from './flow-close-tracker'
 
 module.exports = function (RED: NodeRedApp): void {
-  const isErrorLike = (
-    value: unknown,
-  ): value is { code?: string; message?: string; isOperational?: boolean } =>
-    typeof value === 'object' && value !== null
-  const isInvalidLoginError = (
-    err: { code?: string; message?: string },
-  ): boolean =>
-    err.code === ErrorType.InvalidLogin || /ACCESS_REFUSED/i.test(err.message || '')
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
+  const isInvalidLoginError = (value: unknown): boolean => {
+    const error =
+      typeof value === 'object' && value !== null
+        ? (value as { code?: string; message?: string })
+        : {}
+    return (
+      error.code === ErrorType.InvalidLogin ||
+      /ACCESS_REFUSED/i.test(error.message || '')
+    )
+  }
 
   function AmqpIn(config: EditorNodeProperties): void {
-    let reconnectTimeout: NodeJS.Timeout
-    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
-    let reconnectScheduled = false
-    let recoveringFromDisconnect = false
-    let isShuttingDown = false
-    let initializationVersion = 0
-    let initializationPromise: Promise<void> | null = null
-    let initializationAbortController: AbortController | null = null
-    let connection: ChannelModel | null = null
-    let channel: Channel | null = null
-    let onConnClose: (e: unknown) => Promise<void>
-    let onConnError: (e: unknown) => Promise<void>
-    let onChannelClose: () => Promise<void>
-    let onChannelError: (e: unknown) => Promise<void>
-    let onConsumerCancelled: () => Promise<void>
-    const me = this
-    const reconnectBackoff = new ReconnectBackoff()
-    const nodeEmitter = me as unknown as {
-      on?: (event: string, listener: (...args: unknown[]) => void) => void
-      off?: (event: string, listener: (...args: unknown[]) => void) => void
-    }
-
-
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     RED.nodes.createNode(this, config)
     this.status(NODE_STATUS.Disconnected)
 
-    const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config;
-
-    const amqp = new Amqp(RED, this, configAmqp)
-    const terminalClose = trackTerminalClose(RED, this)
-
-    const reconnectOnError = configAmqp.reconnectOnError;
-
-    const inputListener = async (
-      msg: NodeMessageInFlow & { payload?: { reconnectCall?: boolean } },
-      _: unknown,
-      done?: (err?: Error) => void,
-    ) => {
-      if (msg.payload && msg.payload.reconnectCall && typeof reconnect === 'function') {
-        try {
-          await reconnect()
-          done && done()
-        } catch (e) {
-          done && done(toError(e))
-        }
-      } else {
-        done && done()
-      }
+    const node = this
+    const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config
+    const amqp = new Amqp(RED, node, configAmqp)
+    const terminalClose = trackTerminalClose(RED, node)
+    const reconnectOnError = configAmqp.reconnectOnError
+    const nodeEmitter = node as unknown as {
+      on?: (event: string, listener: (...args: unknown[]) => void) => void
+      off?: (event: string, listener: (...args: unknown[]) => void) => void
     }
-
-    // receive input reconnectCall
-    this.on('input', inputListener)
-    // When the node is re-deployed
-    this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
-      const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
-      const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
-      const removeBindings = terminalClose.shouldRemoveBindings(removed)
-      terminalClose.dispose()
-      isShuttingDown = true
-      initializationVersion += 1
-      initializationAbortController?.abort(
-        new Error('AMQP initialization cancelled during shutdown'),
-      )
-      clearTimeout(reconnectTimeout)
-      removeEventListeners()
-      let closeError: unknown
-      try {
-        await amqp.close(removeBindings ? { removeBindings: true } : undefined)
-      } catch (e) {
-        closeError = e
-      } finally {
-        if (removed) {
-          amqp.removeBrokerNodeState()
-        }
-      }
-
-      if (closeError) {
-        done && done(toError(closeError))
-        return
-      }
-
-      done && done()
-    })
-    
+    let connection: ChannelModel | null = null
+    let channel: Channel | null = null
+    let onConnClose: () => Promise<void>
+    let onConnError: (error: unknown) => Promise<void>
+    let onChannelClose: () => Promise<void>
+    let onChannelError: (error: unknown) => Promise<void>
+    let onConsumerCancelled: () => Promise<void>
+    let lifecycle: AmqpLifecycleCoordinator
 
     const removeEventListeners = (): void => {
       if (typeof onConnClose === 'function') {
@@ -124,227 +70,200 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
-    async function initializeNode(nodeIns: Node) {
-      const attemptVersion = initializationVersion
-      const abortController = new AbortController()
-      initializationAbortController = abortController
-      const initializationIsStale = (): boolean =>
-        isShuttingDown || attemptVersion !== initializationVersion
-
-      reconnect = async (continueUntilConnected = false) => {
-        recoveringFromDisconnect ||= continueUntilConnected
-        if (isShuttingDown || reconnectScheduled) {
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect skipped: node is shutting down')
-          }
-          return
-        }
-        initializationVersion += 1
-        initializationAbortController?.abort(
-          new Error('AMQP initialization cancelled for reconnect'),
-        )
-        reconnectScheduled = true
-        clearTimeout(reconnectTimeout)
-        try {
-          nodeIns.log('Reconnect requested: closing AMQP resources')
-          removeEventListeners()
-          await amqp.close()
-          if (isShuttingDown) {
-            reconnectScheduled = false
-            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
-            return
-          }
-          channel = null
-          connection = null
-
-          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
-          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
-          reconnectTimeout = setTimeout(() => {
-            if (isShuttingDown) {
-              reconnectScheduled = false
-              nodeIns.log('Reconnect timer fired but node is shutting down')
-              return
-            }
-            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns, true)
-          }, reconnectDelayMs)
-        } catch (error) {
-          reconnectScheduled = false
-          throw error
-        }
-      }
-
-      try {
-        connection = await amqp.connect({ signal: abortController.signal })
-        if (initializationIsStale()) {
-          await amqp.close().catch(() => undefined)
-          return
-        }
-
-        // istanbul ignore else
-        if (connection) {
-          channel = await amqp.initialize({
-            signal: abortController.signal,
-          })
-          if (initializationIsStale()) {
-            await amqp.close().catch(() => undefined)
-            return
-          }
-          await amqp.consume()
-          if (initializationIsStale()) {
-            await amqp.close().catch(() => undefined)
-            return
-          }
-
-          onConnClose = async () => {
-            nodeIns.warn('AMQP connection closed event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
-              })
-            }
-          }
-
-          onConnError = async e => {
-            if (reconnectOnError) {
-              try {
-                await reconnect()
-              } catch (reconnectError) {
-                nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
-                  payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
-                })
-              }
-            }
-            nodeIns.error(`Connection error ${e}`, {
-              payload: { error: e, location: ErrorLocationEnum.ConnectionErrorEvent },
-            })
-          }
-
-          onChannelClose = async () => {
-            nodeIns.warn('AMQP channel closed event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-              })
-            }
-          }
-
-          onChannelError = async e => {
-            if (reconnectOnError) {
-              try {
-                await reconnect()
-              } catch (reconnectError) {
-                nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
-                  payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-                })
-              }
-            }
-            nodeIns.error(`Channel error ${e}`, {
-              payload: { error: e, location: ErrorLocationEnum.ChannelErrorEvent },
-            })
-          }
-
-          onConsumerCancelled = async () => {
-            nodeIns.warn('AMQP consumer cancelled event received')
-            try {
-              await reconnect(true)
-            } catch (reconnectError) {
-              nodeIns.error(`Reconnect failed after consumer cancellation: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
-              })
-            }
-          }
-
-          connection.on('close', onConnClose)
-          connection.on('error', onConnError)
-          channel.on('close', onChannelClose)
-          channel.on('error', onChannelError)
-          nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
-
-          amqp.markConnected()
-          recoveringFromDisconnect = false
-          reconnectBackoff.reset()
-        }
-      } catch (e: unknown) {
-        await amqp.close().catch(() => undefined)
-        if (
-          isShuttingDown ||
-          attemptVersion !== initializationVersion
-        ) {
-          return
-        }
-        const err = isErrorLike(e) ? e : {}
-        if (isInvalidLoginError(err)) {
-          nodeIns.status(NODE_STATUS.Invalid)
-          nodeIns.error(`AmqpIn() Could not connect to broker ${e}`, { payload: { error: e, location: ErrorLocationEnum.ConnectError } })
-          if (reconnectOnError || recoveringFromDisconnect) {
-            let reconnectFailed = false
-            await reconnect().catch(reconnectError => {
-              reconnectFailed = true
-              nodeIns.status(NODE_STATUS.Error)
-              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
-              })
-            })
-            if (!reconnectFailed) {
-              nodeIns.status(NODE_STATUS.Invalid)
-            }
-          }
-        } else {
-          nodeIns.error(`AmqpIn() ${e}`, {
-            payload: { error: e, location: ErrorLocationEnum.ConnectError },
-          })
-          if (reconnectOnError || recoveringFromDisconnect) {
-            await reconnect().catch(reconnectError => {
-              nodeIns.status(NODE_STATUS.Error)
-              nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
-                payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
-              })
-            })
-          } else {
-            nodeIns.status(NODE_STATUS.Error)
-          }
-        }
-      } finally {
-        if (initializationAbortController === abortController) {
-          initializationAbortController = null
-        }
-      }
+    const reportReconnectFailure = (
+      message: string,
+      error: unknown,
+      location: ErrorLocationEnum,
+    ): void => {
+      node.error(`${message}: ${error}`, {
+        payload: { error, location },
+      })
     }
 
-    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
-      const previous = initializationPromise
-      const queuedVersion = initializationVersion
-      const startInitialization = (): Promise<void> => {
-        if (scheduledReconnect) {
-          reconnectScheduled = false
-        }
-        if (isShuttingDown || queuedVersion !== initializationVersion) {
-          return Promise.resolve()
-        }
-        return initializeNode(nodeIns)
+    const setupEventListeners = (): void => {
+      onConnClose = async () => {
+        node.warn('AMQP connection closed event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after connection close',
+              error,
+              ErrorLocationEnum.ConnectionErrorEvent,
+            ),
+          )
       }
-      const operation = previous
-        ? previous.catch(() => undefined).then(startInitialization)
-        : startInitialization()
-      initializationPromise = operation
-      void operation
-        .finally(() => {
-          if (initializationPromise === operation) {
-            initializationPromise = null
-          }
+      onConnError = async error => {
+        if (reconnectOnError) {
+          await lifecycle
+            .reconnect()
+            .catch(reconnectError =>
+              reportReconnectFailure(
+                'Reconnect failed after connection error',
+                reconnectError,
+                ErrorLocationEnum.ConnectionErrorEvent,
+              ),
+            )
+        }
+        node.error(`Connection error ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectionErrorEvent },
         })
-        .catch(() => undefined)
-      return operation
+      }
+      onChannelClose = async () => {
+        node.warn('AMQP channel closed event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after channel close',
+              error,
+              ErrorLocationEnum.ChannelErrorEvent,
+            ),
+          )
+      }
+      onChannelError = async error => {
+        if (reconnectOnError) {
+          await lifecycle
+            .reconnect()
+            .catch(reconnectError =>
+              reportReconnectFailure(
+                'Reconnect failed after channel error',
+                reconnectError,
+                ErrorLocationEnum.ChannelErrorEvent,
+              ),
+            )
+        }
+        node.error(`Channel error ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ChannelErrorEvent },
+        })
+      }
+      onConsumerCancelled = async () => {
+        node.warn('AMQP consumer cancelled event received')
+        await lifecycle
+          .reconnect(true)
+          .catch(error =>
+            reportReconnectFailure(
+              'Reconnect failed after consumer cancellation',
+              error,
+              ErrorLocationEnum.ChannelErrorEvent,
+            ),
+          )
+      }
+      connection?.on('close', onConnClose)
+      connection?.on('error', onConnError)
+      channel?.on('close', onChannelClose)
+      channel?.on('error', onChannelError)
+      nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
     }
 
-    // call
-    void queueInitialization(this)
+    const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
+      connection = await amqp.connect({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      channel = await amqp.initialize({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      await amqp.consume()
+      if (attempt.isStale()) return
+      setupEventListeners()
+      amqp.markConnected()
+    }
+
+    const onInitializationError = async (
+      error: unknown,
+      recovering: boolean,
+    ): Promise<void> => {
+      if (isInvalidLoginError(error)) {
+        node.status(NODE_STATUS.Invalid)
+        node.error(`AmqpIn() Could not connect to broker ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      } else {
+        node.error(`AmqpIn() ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      }
+
+      if (reconnectOnError || recovering) {
+        let reconnectFailed = false
+        await lifecycle.reconnect().catch(reconnectError => {
+          reconnectFailed = true
+          node.status(NODE_STATUS.Error)
+          reportReconnectFailure(
+            'Reconnect failed during initialization',
+            reconnectError,
+            ErrorLocationEnum.ConnectError,
+          )
+        })
+        if (isInvalidLoginError(error) && !reconnectFailed) {
+          node.status(NODE_STATUS.Invalid)
+        }
+      } else if (!isInvalidLoginError(error)) {
+        node.status(NODE_STATUS.Error)
+      }
+    }
+
+    lifecycle = new AmqpLifecycleCoordinator({
+      node,
+      initialize,
+      close: () => amqp.close(),
+      removeEventListeners,
+      clearResources: () => {
+        connection = null
+        channel = null
+      },
+      onInitializationError,
+    })
+
+    node.on(
+      'input',
+      async (
+        msg: NodeMessageInFlow & { payload?: { reconnectCall?: boolean } },
+        _: unknown,
+        done?: (error?: Error) => void,
+      ) => {
+        if (msg.payload?.reconnectCall) {
+          await lifecycle
+            .reconnect()
+            .then(() => done?.())
+            .catch(error => done?.(toError(error)))
+        } else {
+          done?.()
+        }
+      },
+    )
+
+    node.on(
+      'close',
+      async (
+        removedOrDone: boolean | ((error?: Error) => void),
+        doneMaybe?: (error?: Error) => void,
+      ): Promise<void> => {
+        const removed =
+          typeof removedOrDone === 'boolean' ? removedOrDone : false
+        const done =
+          typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
+        const removeBindings = terminalClose.shouldRemoveBindings(removed)
+        terminalClose.dispose()
+        lifecycle.shutdown(
+          new Error('AMQP initialization cancelled during shutdown'),
+        )
+        try {
+          await amqp.close(
+            removeBindings ? { removeBindings: true } : undefined,
+          )
+          done?.()
+        } catch (error) {
+          done?.(toError(error))
+        } finally {
+          if (removed) {
+            amqp.removeBrokerNodeState()
+          }
+        }
+      },
+    )
+
+    void lifecycle.start()
   }
+
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   RED.nodes.registerType(NodeType.AmqpIn, AmqpIn)

--- a/src/nodes/amqp-in.ts
+++ b/src/nodes/amqp-in.ts
@@ -1,32 +1,12 @@
 import { NodeRedApp, EditorNodeProperties, NodeMessageInFlow } from 'node-red'
-import { Channel, ChannelModel } from 'amqplib'
 import { NODE_STATUS } from '../constants'
-import {
-  AmqpInNodeDefaults,
-  AmqpOutNodeDefaults,
-  ErrorType,
-  NodeType,
-  ErrorLocationEnum,
-} from '../types'
+import { AmqpInNodeDefaults, AmqpOutNodeDefaults, NodeType } from '../types'
 import Amqp from '../Amqp'
-import AmqpLifecycleCoordinator, {
-  LifecycleAttempt,
-} from '../amqp-lifecycle-coordinator'
-import trackTerminalClose from './flow-close-tracker'
+import createAmqpInputLifecycle from './amqp-input-lifecycle'
 
 module.exports = function (RED: NodeRedApp): void {
   const toError = (value: unknown): Error =>
     value instanceof Error ? value : new Error(String(value))
-  const isInvalidLoginError = (value: unknown): boolean => {
-    const error =
-      typeof value === 'object' && value !== null
-        ? (value as { code?: string; message?: string })
-        : {}
-    return (
-      error.code === ErrorType.InvalidLogin ||
-      /ACCESS_REFUSED/i.test(error.message || '')
-    )
-  }
 
   function AmqpIn(config: EditorNodeProperties): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -37,231 +17,32 @@ module.exports = function (RED: NodeRedApp): void {
     const node = this
     const configAmqp: AmqpInNodeDefaults & AmqpOutNodeDefaults = config
     const amqp = new Amqp(RED, node, configAmqp)
-    const terminalClose = trackTerminalClose(RED, node)
-    const reconnectOnError = configAmqp.reconnectOnError
-    const nodeEmitter = node as unknown as {
-      on?: (event: string, listener: (...args: unknown[]) => void) => void
-      off?: (event: string, listener: (...args: unknown[]) => void) => void
-    }
-    let connection: ChannelModel | null = null
-    let channel: Channel | null = null
-    let onConnClose: () => Promise<void>
-    let onConnError: (error: unknown) => Promise<void>
-    let onChannelClose: () => Promise<void>
-    let onChannelError: (error: unknown) => Promise<void>
-    let onConsumerCancelled: () => Promise<void>
-    let lifecycle: AmqpLifecycleCoordinator
-
-    const removeEventListeners = (): void => {
-      if (typeof onConnClose === 'function') {
-        connection?.off?.('close', onConnClose)
-      }
-      if (typeof onConnError === 'function') {
-        connection?.off?.('error', onConnError)
-      }
-      if (typeof onChannelClose === 'function') {
-        channel?.off?.('close', onChannelClose)
-      }
-      if (typeof onChannelError === 'function') {
-        channel?.off?.('error', onChannelError)
-      }
-      if (typeof onConsumerCancelled === 'function') {
-        nodeEmitter.off?.('amqp:consumer-cancelled', onConsumerCancelled)
-      }
-    }
-
-    const reportReconnectFailure = (
-      message: string,
-      error: unknown,
-      location: ErrorLocationEnum,
-    ): void => {
-      node.error(`${message}: ${error}`, {
-        payload: { error, location },
-      })
-    }
-
-    const setupEventListeners = (): void => {
-      onConnClose = async () => {
-        node.warn('AMQP connection closed event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after connection close',
-              error,
-              ErrorLocationEnum.ConnectionErrorEvent,
-            ),
-          )
-      }
-      onConnError = async error => {
-        if (reconnectOnError) {
-          await lifecycle
-            .reconnect()
-            .catch(reconnectError =>
-              reportReconnectFailure(
-                'Reconnect failed after connection error',
-                reconnectError,
-                ErrorLocationEnum.ConnectionErrorEvent,
-              ),
-            )
-        }
-        node.error(`Connection error ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectionErrorEvent },
-        })
-      }
-      onChannelClose = async () => {
-        node.warn('AMQP channel closed event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after channel close',
-              error,
-              ErrorLocationEnum.ChannelErrorEvent,
-            ),
-          )
-      }
-      onChannelError = async error => {
-        if (reconnectOnError) {
-          await lifecycle
-            .reconnect()
-            .catch(reconnectError =>
-              reportReconnectFailure(
-                'Reconnect failed after channel error',
-                reconnectError,
-                ErrorLocationEnum.ChannelErrorEvent,
-              ),
-            )
-        }
-        node.error(`Channel error ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ChannelErrorEvent },
-        })
-      }
-      onConsumerCancelled = async () => {
-        node.warn('AMQP consumer cancelled event received')
-        await lifecycle
-          .reconnect(true)
-          .catch(error =>
-            reportReconnectFailure(
-              'Reconnect failed after consumer cancellation',
-              error,
-              ErrorLocationEnum.ChannelErrorEvent,
-            ),
-          )
-      }
-      connection?.on('close', onConnClose)
-      connection?.on('error', onConnError)
-      channel?.on('close', onChannelClose)
-      channel?.on('error', onChannelError)
-      nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
-    }
-
-    const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
-      connection = await amqp.connect({ signal: attempt.signal })
-      if (attempt.isStale()) return
-      channel = await amqp.initialize({ signal: attempt.signal })
-      if (attempt.isStale()) return
-      await amqp.consume()
-      if (attempt.isStale()) return
-      setupEventListeners()
-      amqp.markConnected()
-    }
-
-    const onInitializationError = async (
-      error: unknown,
-      recovering: boolean,
-    ): Promise<void> => {
-      if (isInvalidLoginError(error)) {
-        node.status(NODE_STATUS.Invalid)
-        node.error(`AmqpIn() Could not connect to broker ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectError },
-        })
-      } else {
-        node.error(`AmqpIn() ${error}`, {
-          payload: { error, location: ErrorLocationEnum.ConnectError },
-        })
-      }
-
-      if (reconnectOnError || recovering) {
-        let reconnectFailed = false
-        await lifecycle.reconnect().catch(reconnectError => {
-          reconnectFailed = true
-          node.status(NODE_STATUS.Error)
-          reportReconnectFailure(
-            'Reconnect failed during initialization',
-            reconnectError,
-            ErrorLocationEnum.ConnectError,
-          )
-        })
-        if (isInvalidLoginError(error) && !reconnectFailed) {
-          node.status(NODE_STATUS.Invalid)
-        }
-      } else if (!isInvalidLoginError(error)) {
-        node.status(NODE_STATUS.Error)
-      }
-    }
-
-    lifecycle = new AmqpLifecycleCoordinator({
+    createAmqpInputLifecycle({
+      RED,
       node,
-      initialize,
-      close: () => amqp.close(),
-      removeEventListeners,
-      clearResources: () => {
-        connection = null
-        channel = null
-      },
-      onInitializationError,
-    })
-
-    node.on(
-      'input',
-      async (
-        msg: NodeMessageInFlow & { payload?: { reconnectCall?: boolean } },
-        _: unknown,
-        done?: (error?: Error) => void,
-      ) => {
-        if (msg.payload?.reconnectCall) {
-          await lifecycle
-            .reconnect()
-            .then(() => done?.())
-            .catch(error => done?.(toError(error)))
-        } else {
-          done?.()
-        }
-      },
-    )
-
-    node.on(
-      'close',
-      async (
-        removedOrDone: boolean | ((error?: Error) => void),
-        doneMaybe?: (error?: Error) => void,
-      ): Promise<void> => {
-        const removed =
-          typeof removedOrDone === 'boolean' ? removedOrDone : false
-        const done =
-          typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
-        const removeBindings = terminalClose.shouldRemoveBindings(removed)
-        terminalClose.dispose()
-        lifecycle.shutdown(
-          new Error('AMQP initialization cancelled during shutdown'),
+      config: configAmqp,
+      amqp,
+      nodeName: 'AmqpIn()',
+      registerInput: lifecycle => {
+        node.on(
+          'input',
+          async (
+            msg: NodeMessageInFlow & { payload?: { reconnectCall?: boolean } },
+            _: unknown,
+            done?: (error?: Error) => void,
+          ) => {
+            if (msg.payload?.reconnectCall) {
+              await lifecycle
+                .reconnect()
+                .then(() => done?.())
+                .catch(error => done?.(toError(error)))
+            } else {
+              done?.()
+            }
+          },
         )
-        try {
-          await amqp.close(
-            removeBindings ? { removeBindings: true } : undefined,
-          )
-          done?.()
-        } catch (error) {
-          done?.(toError(error))
-        } finally {
-          if (removed) {
-            amqp.removeBrokerNodeState()
-          }
-        }
       },
-    )
-
-    void lifecycle.start()
+    })
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/nodes/amqp-input-lifecycle.ts
+++ b/src/nodes/amqp-input-lifecycle.ts
@@ -1,0 +1,208 @@
+import { Node, NodeRedApp } from 'node-red'
+import { Channel, ChannelModel } from 'amqplib'
+import { NODE_STATUS } from '../constants'
+import {
+  AmqpInNodeDefaults,
+  AmqpOutNodeDefaults,
+  ErrorLocationEnum,
+  ErrorType,
+} from '../types'
+import Amqp from '../Amqp'
+import AmqpLifecycleCoordinator, {
+  LifecycleAttempt,
+} from '../amqp-lifecycle-coordinator'
+import trackTerminalClose from './flow-close-tracker'
+
+export interface AmqpInputLifecycleOptions {
+  RED: NodeRedApp
+  node: Node
+  config: AmqpInNodeDefaults & AmqpOutNodeDefaults
+  amqp: Amqp
+  nodeName: string
+  registerInput: (lifecycle: AmqpLifecycleCoordinator) => void
+}
+
+export default function createAmqpInputLifecycle(
+  options: AmqpInputLifecycleOptions,
+): AmqpLifecycleCoordinator {
+  const { RED, node, config, amqp, nodeName, registerInput } = options
+  const terminalClose = trackTerminalClose(RED, node)
+  const reconnectOnError = config.reconnectOnError
+  const nodeEmitter = node as unknown as {
+    on?: (event: string, listener: (...args: unknown[]) => void) => void
+    off?: (event: string, listener: (...args: unknown[]) => void) => void
+  }
+  let connection: ChannelModel | null = null
+  let channel: Channel | null = null
+  let onConnClose: () => Promise<void>
+  let onConnError: (error: unknown) => Promise<void>
+  let onChannelClose: () => Promise<void>
+  let onChannelError: (error: unknown) => Promise<void>
+  let onConsumerCancelled: () => Promise<void>
+  let lifecycle: AmqpLifecycleCoordinator
+
+  const isInvalidLoginError = (value: unknown): boolean => {
+    const error =
+      typeof value === 'object' && value !== null
+        ? (value as { code?: string; message?: string })
+        : {}
+    return (
+      error.code === ErrorType.InvalidLogin ||
+      /ACCESS_REFUSED/i.test(error.message || '')
+    )
+  }
+
+  const reportReconnectFailure = (
+    message: string,
+    error: unknown,
+    location: ErrorLocationEnum,
+  ): void => {
+    node.error(`${message}: ${error}`, { payload: { error, location } })
+  }
+
+  const removeEventListeners = (): void => {
+    if (typeof onConnClose === 'function') connection?.off?.('close', onConnClose)
+    if (typeof onConnError === 'function') connection?.off?.('error', onConnError)
+    if (typeof onChannelClose === 'function') channel?.off?.('close', onChannelClose)
+    if (typeof onChannelError === 'function') channel?.off?.('error', onChannelError)
+    if (typeof onConsumerCancelled === 'function') {
+      nodeEmitter.off?.('amqp:consumer-cancelled', onConsumerCancelled)
+    }
+  }
+
+  const setupEventListeners = (): void => {
+    onConnClose = async () => {
+      node.warn('AMQP connection closed event received')
+      await lifecycle.reconnect(true).catch(error =>
+        reportReconnectFailure(
+          'Reconnect failed after connection close',
+          error,
+          ErrorLocationEnum.ConnectionErrorEvent,
+        ),
+      )
+    }
+    onConnError = async error => {
+      if (reconnectOnError) {
+        await lifecycle.reconnect().catch(reconnectError =>
+          reportReconnectFailure(
+            'Reconnect failed after connection error',
+            reconnectError,
+            ErrorLocationEnum.ConnectionErrorEvent,
+          ),
+        )
+      }
+      node.error(`Connection error ${error}`, {
+        payload: { error, location: ErrorLocationEnum.ConnectionErrorEvent },
+      })
+    }
+    onChannelClose = async () => {
+      node.warn('AMQP channel closed event received')
+      await lifecycle.reconnect(true).catch(error =>
+        reportReconnectFailure(
+          'Reconnect failed after channel close',
+          error,
+          ErrorLocationEnum.ChannelErrorEvent,
+        ),
+      )
+    }
+    onChannelError = async error => {
+      if (reconnectOnError) {
+        await lifecycle.reconnect().catch(reconnectError =>
+          reportReconnectFailure(
+            'Reconnect failed after channel error',
+            reconnectError,
+            ErrorLocationEnum.ChannelErrorEvent,
+          ),
+        )
+      }
+      node.error(`Channel error ${error}`, {
+        payload: { error, location: ErrorLocationEnum.ChannelErrorEvent },
+      })
+    }
+    onConsumerCancelled = async () => {
+      node.warn('AMQP consumer cancelled event received')
+      await lifecycle.reconnect(true).catch(error =>
+        reportReconnectFailure(
+          'Reconnect failed after consumer cancellation',
+          error,
+          ErrorLocationEnum.ChannelErrorEvent,
+        ),
+      )
+    }
+    connection?.on('close', onConnClose)
+    connection?.on('error', onConnError)
+    channel?.on('close', onChannelClose)
+    channel?.on('error', onChannelError)
+    nodeEmitter.on?.('amqp:consumer-cancelled', onConsumerCancelled)
+  }
+
+  const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
+    connection = await amqp.connect({ signal: attempt.signal })
+    if (attempt.isStale()) return
+    channel = await amqp.initialize({ signal: attempt.signal })
+    if (attempt.isStale()) return
+    await amqp.consume()
+    if (attempt.isStale()) return
+    setupEventListeners()
+    amqp.markConnected()
+  }
+
+  lifecycle = new AmqpLifecycleCoordinator({
+    node,
+    initialize,
+    close: () => amqp.close(),
+    removeEventListeners,
+    clearResources: () => {
+      connection = null
+      channel = null
+    },
+    onInitializationError: async (error, recovering) => {
+      const invalidLogin = isInvalidLoginError(error)
+      if (invalidLogin) {
+        node.status(NODE_STATUS.Invalid)
+        node.error(`${nodeName} Could not connect to broker ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      } else {
+        node.error(`${nodeName} ${error}`, {
+          payload: { error, location: ErrorLocationEnum.ConnectError },
+        })
+      }
+      if (reconnectOnError || recovering) {
+        let failed = false
+        await lifecycle.reconnect().catch(reconnectError => {
+          failed = true
+          node.status(NODE_STATUS.Error)
+          reportReconnectFailure(
+            'Reconnect failed during initialization',
+            reconnectError,
+            ErrorLocationEnum.ConnectError,
+          )
+        })
+        if (invalidLogin && !failed) node.status(NODE_STATUS.Invalid)
+      } else if (!invalidLogin) {
+        node.status(NODE_STATUS.Error)
+      }
+    },
+  })
+
+  registerInput(lifecycle)
+  node.on('close', async (removedOrDone: boolean | ((error?: Error) => void), doneMaybe?: (error?: Error) => void) => {
+    const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
+    const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
+    const removeBindings = terminalClose.shouldRemoveBindings(removed)
+    terminalClose.dispose()
+    lifecycle.shutdown(new Error('AMQP initialization cancelled during shutdown'))
+    try {
+      await amqp.close(removeBindings ? { removeBindings: true } : undefined)
+      done?.()
+    } catch (error) {
+      done?.(error instanceof Error ? error : new Error(String(error)))
+    } finally {
+      if (removed) amqp.removeBrokerNodeState()
+    }
+  })
+
+  void lifecycle.start()
+  return lifecycle
+}

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -2,8 +2,14 @@ import { NodeRedApp, EditorNodeProperties, Node, NodeMessageInFlow } from 'node-
 import { NODE_STATUS } from '../constants'
 import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorLocationEnum, ErrorType, NodeType } from '../types'
 import Amqp from '../Amqp'
-import { MessageProperties, Channel, ChannelModel } from 'amqplib'
+import { Options, Channel, ChannelModel } from 'amqplib'
 import ReconnectBackoff from '../reconnect-backoff'
+
+type AmqpOutMessage = NodeMessageInFlow & {
+  routingKey?: string
+  vhost?: string
+  properties?: Options.Publish
+}
 
 module.exports = function (RED: NodeRedApp): void {
   const isErrorLike = (
@@ -25,9 +31,13 @@ module.exports = function (RED: NodeRedApp): void {
     },
   ): void {
     let reconnectTimeout: NodeJS.Timeout
-    let reconnect: (() => Promise<void>) | null = null
+    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
     let reconnectScheduled = false
+    let recoveringFromDisconnect = false
     let isShuttingDown = false
+    let initializationVersion = 0
+    let initializationPromise: Promise<void> | null = null
+    let inputSequence: Promise<void> = Promise.resolve()
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -67,7 +77,7 @@ module.exports = function (RED: NodeRedApp): void {
       onConnClose = async () => {
         nodeIns.warn('AMQP connection closed event received')
         try {
-          await reconnect()
+          await reconnect(true)
         } catch (reconnectError) {
           nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
             payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
@@ -93,7 +103,7 @@ module.exports = function (RED: NodeRedApp): void {
       onChannelClose = async () => {
         nodeIns.warn('AMQP channel closed event received')
         try {
-          await reconnect()
+          await reconnect(true)
         } catch (reconnectError) {
           nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
             payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -129,7 +139,7 @@ module.exports = function (RED: NodeRedApp): void {
         nodeIns.error(`AmqpOut() Could not connect to broker ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
-        if (reconnectOnError) {
+        if (reconnectOnError || recoveringFromDisconnect) {
           let reconnectFailed = false
           await reconnect().catch(reconnectError => {
             reconnectFailed = true
@@ -146,7 +156,7 @@ module.exports = function (RED: NodeRedApp): void {
         nodeIns.error(`AmqpOut() ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
-        if (reconnectOnError) {
+        if (reconnectOnError || recoveringFromDisconnect) {
           await reconnect().catch(reconnectError => {
             nodeIns.status(NODE_STATUS.Error)
             nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
@@ -160,15 +170,27 @@ module.exports = function (RED: NodeRedApp): void {
     }
 
     // handle input event
-    const inputListener = async (
-      msg: NodeMessageInFlow & {
-        routingKey?: string
-        vhost?: string
-        properties?: MessageProperties
-      },
+    const processInput = async (
+      msg: AmqpOutMessage,
       _: unknown,
       done?: (err?: Error) => void,
     ) => {
+      const stopIfShuttingDown = async (): Promise<boolean> => {
+        if (!isShuttingDown) {
+          return false
+        }
+
+        await amqp.close().catch(error => {
+          me.error(`Could not close AMQP resources during shutdown: ${error}`)
+        })
+        done && done(new Error('AMQP output node is shutting down'))
+        return true
+      }
+
+      if (isShuttingDown) {
+        done && done(new Error('AMQP output node is shutting down'))
+        return
+      }
       const { payload, routingKey, vhost, properties: msgProperties } = msg
       const {
         exchangeRoutingKey,
@@ -177,7 +199,7 @@ module.exports = function (RED: NodeRedApp): void {
       } = config
 
       // message properties override config properties
-      let properties: MessageProperties
+      let properties: Options.Publish
       try {
         properties = {
           ...JSON.parse(amqpProperties),
@@ -219,6 +241,10 @@ module.exports = function (RED: NodeRedApp): void {
               })
             })
 
+            if (isShuttingDown && (await stopIfShuttingDown())) {
+              return
+            }
+
             if (typeof result !== 'string') {
               this.warn(
                 `Routing key JSONata expression returned ${typeof result}; coercing to string`,
@@ -235,14 +261,8 @@ module.exports = function (RED: NodeRedApp): void {
         }
         case 'str':
         default:
-          if (routingKey) {
-            // if incoming payload contains a routingKey value
-            // override our string value with it.
-
-            // Superfluous (and possibly confusing) at this point
-            // but keeping it to retain backwards compatibility
-            amqp.setRoutingKey(routingKey)
-          }
+          // A message routing key is an override for this message only.
+          amqp.setRoutingKey(routingKey ?? exchangeRoutingKey)
           break
       }
 
@@ -254,15 +274,25 @@ module.exports = function (RED: NodeRedApp): void {
           removeEventListeners()
           await amqp.setVhost(vhost)
 
+          if (isShuttingDown && (await stopIfShuttingDown())) {
+            return
+          }
+
           connection = amqp.getConnection()
           channel = amqp.getChannel()
           setupEventListeners(me)
           amqp.markConnected()
+          recoveringFromDisconnect = false
+          reconnectBackoff.reset()
         } catch (e) {
           await handleError(e, me)
           done && done(toError(e))
           return
         }
+      }
+
+      if (isShuttingDown && (await stopIfShuttingDown())) {
+        return
       }
 
       try {
@@ -275,12 +305,24 @@ module.exports = function (RED: NodeRedApp): void {
       done && done()
     }
 
+    const inputListener = (
+      msg: AmqpOutMessage,
+      send: unknown,
+      done?: (err?: Error) => void,
+    ): void => {
+      const operation = inputSequence.then(() => processInput(msg, send, done))
+      inputSequence = operation.catch(error => {
+        done && done(toError(error))
+      })
+    }
+
     this.on('input', inputListener)
     // When the node is re-deployed
     this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
+      initializationVersion += 1
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -303,19 +345,27 @@ module.exports = function (RED: NodeRedApp): void {
     })
 
     async function initializeNode(nodeIns: Node) {
-      reconnect = async () => {
+      const attemptVersion = initializationVersion
+      const initializationIsStale = (): boolean =>
+        isShuttingDown || attemptVersion !== initializationVersion
+
+      reconnect = async (continueUntilConnected = false) => {
+        recoveringFromDisconnect ||= continueUntilConnected
         if (isShuttingDown || reconnectScheduled) {
           if (isShuttingDown) {
             nodeIns.log('Reconnect skipped: node is shutting down')
           }
           return
         }
+        initializationVersion += 1
         reconnectScheduled = true
         clearTimeout(reconnectTimeout)
         try {
           nodeIns.log('Reconnect requested: closing AMQP resources')
           removeEventListeners()
-          await amqp.close()
+          await amqp.close(
+            new Error('AMQP connection interrupted; reconnecting'),
+          )
           if (isShuttingDown) {
             reconnectScheduled = false
             nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
@@ -333,7 +383,7 @@ module.exports = function (RED: NodeRedApp): void {
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void initializeNode(nodeIns)
+            void queueInitialization(nodeIns)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -343,27 +393,51 @@ module.exports = function (RED: NodeRedApp): void {
 
       try {
         connection = await amqp.connect()
+        if (initializationIsStale()) {
+          await amqp.close().catch(() => undefined)
+          return
+        }
         if (connection) {
           channel = await amqp.initialize()
-          if (isShuttingDown) {
+          if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
           }
           setupEventListeners(nodeIns)
           amqp.markConnected()
+          recoveringFromDisconnect = false
           reconnectBackoff.reset()
         }
       } catch (e) {
         await amqp.close().catch(() => undefined)
-        if (isShuttingDown) {
+        if (
+          isShuttingDown ||
+          attemptVersion !== initializationVersion
+        ) {
           return
         }
         await handleError(e, nodeIns)
       }
     }
 
+    function queueInitialization(nodeIns: Node): Promise<void> {
+      const previous = initializationPromise
+      const operation = previous
+        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
+        : initializeNode(nodeIns)
+      initializationPromise = operation
+      void operation
+        .finally(() => {
+          if (initializationPromise === operation) {
+            initializationPromise = null
+          }
+        })
+        .catch(() => undefined)
+      return operation
+    }
+
     // call
-    initializeNode(this);
+    void queueInitialization(this)
   }
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -37,6 +37,7 @@ module.exports = function (RED: NodeRedApp): void {
     let isShuttingDown = false
     let initializationVersion = 0
     let initializationPromise: Promise<void> | null = null
+    let initializationAbortController: AbortController | null = null
     let vhostSequence: Promise<void> = Promise.resolve()
     const activePublishes = new Set<Promise<void>>()
     let connection: ChannelModel | null = null
@@ -273,6 +274,9 @@ module.exports = function (RED: NodeRedApp): void {
           reconnectScheduled = false
 
           initializationVersion += 1
+          initializationAbortController?.abort(
+            new Error('AMQP initialization cancelled for virtual host switch'),
+          )
           const pendingInitialization = initializationPromise
           if (pendingInitialization) {
             await pendingInitialization.catch(() => undefined)
@@ -351,6 +355,9 @@ module.exports = function (RED: NodeRedApp): void {
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
       isShuttingDown = true
       initializationVersion += 1
+      initializationAbortController?.abort(
+        new Error('AMQP initialization cancelled during shutdown'),
+      )
       clearTimeout(reconnectTimeout)
       removeEventListeners()
       let closeError: unknown
@@ -374,6 +381,8 @@ module.exports = function (RED: NodeRedApp): void {
 
     async function initializeNode(nodeIns: Node) {
       const attemptVersion = initializationVersion
+      const abortController = new AbortController()
+      initializationAbortController = abortController
       const initializationIsStale = (): boolean =>
         isShuttingDown || attemptVersion !== initializationVersion
 
@@ -386,6 +395,7 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         initializationVersion += 1
+        const reconnectVersion = initializationVersion
         reconnectScheduled = true
         clearTimeout(reconnectTimeout)
         try {
@@ -394,9 +404,15 @@ module.exports = function (RED: NodeRedApp): void {
           await amqp.close(
             new Error('AMQP connection interrupted; reconnecting'),
           )
-          if (isShuttingDown) {
+          if (
+            isShuttingDown ||
+            reconnectVersion !== initializationVersion ||
+            !reconnectScheduled
+          ) {
             reconnectScheduled = false
-            nodeIns.log('Reconnect aborted: node started shutting down while closing AMQP resources')
+            nodeIns.log(
+              'Reconnect aborted: request was superseded while closing AMQP resources',
+            )
             return
           }
           channel = null
@@ -420,13 +436,15 @@ module.exports = function (RED: NodeRedApp): void {
       }
 
       try {
-        connection = await amqp.connect()
+        connection = await amqp.connect({ signal: abortController.signal })
         if (initializationIsStale()) {
           await amqp.close().catch(() => undefined)
           return
         }
         if (connection) {
-          channel = await amqp.initialize()
+          channel = await amqp.initialize({
+            signal: abortController.signal,
+          })
           if (initializationIsStale()) {
             await amqp.close().catch(() => undefined)
             return
@@ -445,14 +463,22 @@ module.exports = function (RED: NodeRedApp): void {
           return
         }
         await handleError(e, nodeIns)
+      } finally {
+        if (initializationAbortController === abortController) {
+          initializationAbortController = null
+        }
       }
     }
 
     function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const queuedVersion = initializationVersion
       const startInitialization = (): Promise<void> => {
         if (scheduledReconnect) {
           reconnectScheduled = false
+        }
+        if (isShuttingDown || queuedVersion !== initializationVersion) {
+          return Promise.resolve()
         }
         return initializeNode(nodeIns)
       }

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -272,6 +272,16 @@ module.exports = function (RED: NodeRedApp): void {
           clearTimeout(reconnectTimeout)
           reconnectScheduled = false
 
+          initializationVersion += 1
+          const pendingInitialization = initializationPromise
+          if (pendingInitialization) {
+            await pendingInitialization.catch(() => undefined)
+          }
+
+          if (isShuttingDown && (await stopIfShuttingDown())) {
+            return
+          }
+
           removeEventListeners()
           await amqp.setVhost(vhost)
 

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -37,7 +37,8 @@ module.exports = function (RED: NodeRedApp): void {
     let isShuttingDown = false
     let initializationVersion = 0
     let initializationPromise: Promise<void> | null = null
-    let inputSequence: Promise<void> = Promise.resolve()
+    let vhostSequence: Promise<void> = Promise.resolve()
+    const activePublishes = new Set<Promise<void>>()
     let connection: ChannelModel | null = null
     let channel: Channel | null = null
     let onConnClose: (e: unknown) => Promise<void>
@@ -197,6 +198,7 @@ module.exports = function (RED: NodeRedApp): void {
         exchangeRoutingKeyType,
         amqpProperties,
       } = config
+      let resolvedRoutingKey = exchangeRoutingKey
 
       // message properties override config properties
       let properties: Options.Publish
@@ -214,7 +216,7 @@ module.exports = function (RED: NodeRedApp): void {
         case 'flow':
         case 'global':
           try {
-            amqp.setRoutingKey(
+            resolvedRoutingKey = String(
               RED.util.evaluateNodeProperty(
                 exchangeRoutingKey,
                 exchangeRoutingKeyType,
@@ -251,7 +253,7 @@ module.exports = function (RED: NodeRedApp): void {
               )
             }
 
-            amqp.setRoutingKey(String(result))
+            resolvedRoutingKey = String(result)
           } catch (err) {
             this.error(`Failed to evaluate JSONata expression: ${err}`)
             done && done(toError(err))
@@ -261,8 +263,7 @@ module.exports = function (RED: NodeRedApp): void {
         }
         case 'str':
         default:
-          // A message routing key is an override for this message only.
-          amqp.setRoutingKey(routingKey ?? exchangeRoutingKey)
+          resolvedRoutingKey = routingKey ?? exchangeRoutingKey
           break
       }
 
@@ -296,7 +297,7 @@ module.exports = function (RED: NodeRedApp): void {
       }
 
       try {
-        await amqp.publish(payload, properties)
+        await amqp.publish(payload, properties, resolvedRoutingKey)
       } catch (e) {
         done && done(toError(e))
         return
@@ -310,10 +311,27 @@ module.exports = function (RED: NodeRedApp): void {
       send: unknown,
       done?: (err?: Error) => void,
     ): void => {
-      const operation = inputSequence.then(() => processInput(msg, send, done))
-      inputSequence = operation.catch(error => {
-        done && done(toError(error))
-      })
+      if (msg.vhost) {
+        const precedingPublishes = [...activePublishes]
+        const operation = vhostSequence.then(async () => {
+          await Promise.allSettled(precedingPublishes)
+          await processInput(msg, send, done)
+        })
+        vhostSequence = operation.catch(error => {
+          done && done(toError(error))
+        })
+        return
+      }
+
+      const operation = vhostSequence.then(() => processInput(msg, send, done))
+      activePublishes.add(operation)
+      void operation
+        .finally(() => {
+          activePublishes.delete(operation)
+        })
+        .catch(error => {
+          done && done(toError(error))
+        })
     }
 
     this.on('input', inputListener)
@@ -327,7 +345,7 @@ module.exports = function (RED: NodeRedApp): void {
       removeEventListeners()
       let closeError: unknown
       try {
-        await amqp.close()
+        await amqp.close(removed ? { removeBindings: true } : undefined)
       } catch (e) {
         closeError = e
       } finally {

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -270,13 +270,15 @@ module.exports = function (RED: NodeRedApp): void {
 
       if (vhost) {
         try {
-          clearTimeout(reconnectTimeout)
-          reconnectScheduled = false
-
-          initializationVersion += 1
-          initializationAbortController?.abort(
-            new Error('AMQP initialization cancelled for virtual host switch'),
-          )
+          const vhostChanged = amqp.getVhost() !== vhost
+          if (vhostChanged) {
+            clearTimeout(reconnectTimeout)
+            reconnectScheduled = false
+            initializationVersion += 1
+            initializationAbortController?.abort(
+              new Error('AMQP initialization cancelled for virtual host switch'),
+            )
+          }
           const pendingInitialization = initializationPromise
           if (pendingInitialization) {
             await pendingInitialization.catch(() => undefined)
@@ -286,19 +288,21 @@ module.exports = function (RED: NodeRedApp): void {
             return
           }
 
-          removeEventListeners()
-          await amqp.setVhost(vhost)
+          if (vhostChanged) {
+            removeEventListeners()
+            await amqp.setVhost(vhost)
 
-          if (isShuttingDown && (await stopIfShuttingDown())) {
-            return
+            if (isShuttingDown && (await stopIfShuttingDown())) {
+              return
+            }
+
+            connection = amqp.getConnection()
+            channel = amqp.getChannel()
+            setupEventListeners(me)
+            amqp.markConnected()
+            recoveringFromDisconnect = false
+            reconnectBackoff.reset()
           }
-
-          connection = amqp.getConnection()
-          channel = amqp.getChannel()
-          setupEventListeners(me)
-          amqp.markConnected()
-          recoveringFromDisconnect = false
-          reconnectBackoff.reset()
         } catch (e) {
           await handleError(e, me)
           done && done(toError(e))

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -395,13 +395,13 @@ module.exports = function (RED: NodeRedApp): void {
           const reconnectDelayMs = reconnectBackoff.nextDelayMs()
           nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
           reconnectTimeout = setTimeout(() => {
-            reconnectScheduled = false
             if (isShuttingDown) {
+              reconnectScheduled = false
               nodeIns.log('Reconnect timer fired but node is shutting down')
               return
             }
             nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns)
+            void queueInitialization(nodeIns, true)
           }, reconnectDelayMs)
         } catch (error) {
           reconnectScheduled = false
@@ -438,11 +438,17 @@ module.exports = function (RED: NodeRedApp): void {
       }
     }
 
-    function queueInitialization(nodeIns: Node): Promise<void> {
+    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
       const previous = initializationPromise
+      const startInitialization = (): Promise<void> => {
+        if (scheduledReconnect) {
+          reconnectScheduled = false
+        }
+        return initializeNode(nodeIns)
+      }
       const operation = previous
-        ? previous.catch(() => undefined).then(() => initializeNode(nodeIns))
-        : initializeNode(nodeIns)
+        ? previous.catch(() => undefined).then(startInitialization)
+        : startInitialization()
       initializationPromise = operation
       void operation
         .finally(() => {

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -3,7 +3,9 @@ import { NODE_STATUS } from '../constants'
 import { AmqpInNodeDefaults, AmqpOutNodeDefaults, ErrorLocationEnum, ErrorType, NodeType } from '../types'
 import Amqp from '../Amqp'
 import { Options, Channel, ChannelModel } from 'amqplib'
-import ReconnectBackoff from '../reconnect-backoff'
+import AmqpLifecycleCoordinator, {
+  LifecycleAttempt,
+} from '../amqp-lifecycle-coordinator'
 
 type AmqpOutMessage = NodeMessageInFlow & {
   routingKey?: string
@@ -30,14 +32,6 @@ module.exports = function (RED: NodeRedApp): void {
       amqpProperties: string
     },
   ): void {
-    let reconnectTimeout: NodeJS.Timeout
-    let reconnect: ((continueUntilConnected?: boolean) => Promise<void>) | null = null
-    let reconnectScheduled = false
-    let recoveringFromDisconnect = false
-    let isShuttingDown = false
-    let initializationVersion = 0
-    let initializationPromise: Promise<void> | null = null
-    let initializationAbortController: AbortController | null = null
     let vhostSequence: Promise<void> = Promise.resolve()
     const activePublishes = new Set<Promise<void>>()
     let connection: ChannelModel | null = null
@@ -47,7 +41,7 @@ module.exports = function (RED: NodeRedApp): void {
     let onChannelClose: () => Promise<void>
     let onChannelError: (e: unknown) => Promise<void>
     const me = this
-    const reconnectBackoff = new ReconnectBackoff()
+    let lifecycle: AmqpLifecycleCoordinator
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -79,7 +73,7 @@ module.exports = function (RED: NodeRedApp): void {
       onConnClose = async () => {
         nodeIns.warn('AMQP connection closed event received')
         try {
-          await reconnect(true)
+          await lifecycle.reconnect(true)
         } catch (reconnectError) {
           nodeIns.error(`Reconnect failed after connection close: ${reconnectError}`, {
             payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
@@ -90,7 +84,7 @@ module.exports = function (RED: NodeRedApp): void {
       onConnError = async e => {
         if (reconnectOnError) {
           try {
-            await reconnect()
+            await lifecycle.reconnect()
           } catch (reconnectError) {
             nodeIns.error(`Reconnect failed after connection error: ${reconnectError}`, {
               payload: { error: reconnectError, location: ErrorLocationEnum.ConnectionErrorEvent },
@@ -105,7 +99,7 @@ module.exports = function (RED: NodeRedApp): void {
       onChannelClose = async () => {
         nodeIns.warn('AMQP channel closed event received')
         try {
-          await reconnect(true)
+          await lifecycle.reconnect(true)
         } catch (reconnectError) {
           nodeIns.error(`Reconnect failed after channel close: ${reconnectError}`, {
             payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -116,7 +110,7 @@ module.exports = function (RED: NodeRedApp): void {
       onChannelError = async e => {
         if (reconnectOnError) {
           try {
-            await reconnect()
+            await lifecycle.reconnect()
           } catch (reconnectError) {
             nodeIns.error(`Reconnect failed after channel error: ${reconnectError}`, {
               payload: { error: reconnectError, location: ErrorLocationEnum.ChannelErrorEvent },
@@ -141,9 +135,9 @@ module.exports = function (RED: NodeRedApp): void {
         nodeIns.error(`AmqpOut() Could not connect to broker ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
-        if (reconnectOnError || recoveringFromDisconnect) {
+        if (reconnectOnError || lifecycle.isRecovering()) {
           let reconnectFailed = false
-          await reconnect().catch(reconnectError => {
+          await lifecycle.reconnect().catch(reconnectError => {
             reconnectFailed = true
             nodeIns.status(NODE_STATUS.Error)
             nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
@@ -158,8 +152,8 @@ module.exports = function (RED: NodeRedApp): void {
         nodeIns.error(`AmqpOut() ${e}`, {
           payload: { error: e, location: ErrorLocationEnum.ConnectError },
         })
-        if (reconnectOnError || recoveringFromDisconnect) {
-          await reconnect().catch(reconnectError => {
+        if (reconnectOnError || lifecycle.isRecovering()) {
+          await lifecycle.reconnect().catch(reconnectError => {
             nodeIns.status(NODE_STATUS.Error)
             nodeIns.error(`Reconnect failed during initialization: ${reconnectError}`, {
               payload: { error: reconnectError, location: ErrorLocationEnum.ConnectError },
@@ -178,7 +172,7 @@ module.exports = function (RED: NodeRedApp): void {
       done?: (err?: Error) => void,
     ) => {
       const stopIfShuttingDown = async (): Promise<boolean> => {
-        if (!isShuttingDown) {
+        if (!lifecycle.isShuttingDown()) {
           return false
         }
 
@@ -189,7 +183,7 @@ module.exports = function (RED: NodeRedApp): void {
         return true
       }
 
-      if (isShuttingDown) {
+      if (lifecycle.isShuttingDown()) {
         done && done(new Error('AMQP output node is shutting down'))
         return
       }
@@ -244,7 +238,7 @@ module.exports = function (RED: NodeRedApp): void {
               })
             })
 
-            if (isShuttingDown && (await stopIfShuttingDown())) {
+            if (lifecycle.isShuttingDown() && (await stopIfShuttingDown())) {
               return
             }
 
@@ -272,56 +266,36 @@ module.exports = function (RED: NodeRedApp): void {
         try {
           const vhostChanged = amqp.getVhost() !== vhost
           if (vhostChanged) {
-            clearTimeout(reconnectTimeout)
-            reconnectScheduled = false
-            initializationVersion += 1
-            initializationAbortController?.abort(
+            lifecycle.supersede(
               new Error('AMQP initialization cancelled for virtual host switch'),
             )
           }
-          const pendingInitialization = initializationPromise
-          if (pendingInitialization) {
-            await pendingInitialization.catch(() => undefined)
-          }
+          await lifecycle.awaitInitialization()
 
-          if (isShuttingDown && (await stopIfShuttingDown())) {
+          if (lifecycle.isShuttingDown() && (await stopIfShuttingDown())) {
             return
           }
 
           const vhostSwitchRequired = !amqp.isInitializedForVhost(vhost)
           if (vhostSwitchRequired) {
-            clearTimeout(reconnectTimeout)
-            reconnectScheduled = false
-            initializationVersion += 1
-            initializationAbortController?.abort(
+            const switched = await lifecycle.replace(
               new Error('AMQP initialization cancelled for virtual host switch'),
+              async attempt => {
+                removeEventListeners()
+                await amqp.setVhost(vhost, { signal: attempt.signal })
+                if (attempt.isStale()) return
+                connection = amqp.getConnection()
+                channel = amqp.getChannel()
+                setupEventListeners(me)
+                amqp.markConnected()
+              },
             )
-            const switchAbortController = new AbortController()
-            initializationAbortController = switchAbortController
-            removeEventListeners()
-            try {
-              await amqp.setVhost(vhost, {
-                signal: switchAbortController.signal,
-              })
-            } finally {
-              if (initializationAbortController === switchAbortController) {
-                initializationAbortController = null
-              }
-            }
-
-            if (isShuttingDown && (await stopIfShuttingDown())) {
+            if (!switched || (await stopIfShuttingDown())) {
               return
             }
-
-            connection = amqp.getConnection()
-            channel = amqp.getChannel()
-            setupEventListeners(me)
-            amqp.markConnected()
-            recoveringFromDisconnect = false
-            reconnectBackoff.reset()
           }
         } catch (e) {
-          if (isShuttingDown) {
+          if (lifecycle.isShuttingDown()) {
             done && done()
             return
           }
@@ -331,7 +305,7 @@ module.exports = function (RED: NodeRedApp): void {
         }
       }
 
-      if (isShuttingDown && (await stopIfShuttingDown())) {
+      if (lifecycle.isShuttingDown() && (await stopIfShuttingDown())) {
         return
       }
 
@@ -378,13 +352,9 @@ module.exports = function (RED: NodeRedApp): void {
     this.on('close', async (removedOrDone: boolean | ((err?: Error) => void), doneMaybe?: (err?: Error) => void): Promise<void> => {
       const removed = typeof removedOrDone === 'boolean' ? removedOrDone : false
       const done = typeof removedOrDone === 'function' ? removedOrDone : doneMaybe
-      isShuttingDown = true
-      initializationVersion += 1
-      initializationAbortController?.abort(
+      lifecycle.shutdown(
         new Error('AMQP initialization cancelled during shutdown'),
       )
-      clearTimeout(reconnectTimeout)
-      removeEventListeners()
       let closeError: unknown
       try {
         await amqp.close(removed ? { removeBindings: true } : undefined)
@@ -404,125 +374,31 @@ module.exports = function (RED: NodeRedApp): void {
       done && done()
     })
 
-    async function initializeNode(nodeIns: Node) {
-      const attemptVersion = initializationVersion
-      const abortController = new AbortController()
-      initializationAbortController = abortController
-      const initializationIsStale = (): boolean =>
-        isShuttingDown || attemptVersion !== initializationVersion
-
-      reconnect = async (continueUntilConnected = false) => {
-        recoveringFromDisconnect ||= continueUntilConnected
-        if (isShuttingDown || reconnectScheduled) {
-          if (isShuttingDown) {
-            nodeIns.log('Reconnect skipped: node is shutting down')
-          }
-          return
-        }
-        initializationVersion += 1
-        const reconnectVersion = initializationVersion
-        reconnectScheduled = true
-        clearTimeout(reconnectTimeout)
-        try {
-          nodeIns.log('Reconnect requested: closing AMQP resources')
-          removeEventListeners()
-          await amqp.close(
-            new Error('AMQP connection interrupted; reconnecting'),
-          )
-          if (
-            isShuttingDown ||
-            reconnectVersion !== initializationVersion ||
-            !reconnectScheduled
-          ) {
-            reconnectScheduled = false
-            nodeIns.log(
-              'Reconnect aborted: request was superseded while closing AMQP resources',
-            )
-            return
-          }
-          channel = null
-          connection = null
-
-          const reconnectDelayMs = reconnectBackoff.nextDelayMs()
-          nodeIns.log(`Reconnect scheduled in ${reconnectDelayMs}ms`)
-          reconnectTimeout = setTimeout(() => {
-            if (isShuttingDown) {
-              reconnectScheduled = false
-              nodeIns.log('Reconnect timer fired but node is shutting down')
-              return
-            }
-            nodeIns.log('Reconnect timer fired: re-initializing AMQP node')
-            void queueInitialization(nodeIns, true)
-          }, reconnectDelayMs)
-        } catch (error) {
-          reconnectScheduled = false
-          throw error
-        }
-      }
-
-      try {
-        connection = await amqp.connect({ signal: abortController.signal })
-        if (initializationIsStale()) {
-          await amqp.close().catch(() => undefined)
-          return
-        }
-        if (connection) {
-          channel = await amqp.initialize({
-            signal: abortController.signal,
-          })
-          if (initializationIsStale()) {
-            await amqp.close().catch(() => undefined)
-            return
-          }
-          setupEventListeners(nodeIns)
-          amqp.markConnected()
-          recoveringFromDisconnect = false
-          reconnectBackoff.reset()
-        }
-      } catch (e) {
-        await amqp.close().catch(() => undefined)
-        if (
-          isShuttingDown ||
-          attemptVersion !== initializationVersion
-        ) {
-          return
-        }
-        await handleError(e, nodeIns)
-      } finally {
-        if (initializationAbortController === abortController) {
-          initializationAbortController = null
-        }
-      }
+    const initialize = async (attempt: LifecycleAttempt): Promise<void> => {
+      connection = await amqp.connect({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      channel = await amqp.initialize({ signal: attempt.signal })
+      if (attempt.isStale()) return
+      setupEventListeners(me)
+      amqp.markConnected()
     }
 
-    function queueInitialization(nodeIns: Node, scheduledReconnect = false): Promise<void> {
-      const previous = initializationPromise
-      const queuedVersion = initializationVersion
-      const startInitialization = (): Promise<void> => {
-        if (scheduledReconnect) {
-          reconnectScheduled = false
-        }
-        if (isShuttingDown || queuedVersion !== initializationVersion) {
-          return Promise.resolve()
-        }
-        return initializeNode(nodeIns)
-      }
-      const operation = previous
-        ? previous.catch(() => undefined).then(startInitialization)
-        : startInitialization()
-      initializationPromise = operation
-      void operation
-        .finally(() => {
-          if (initializationPromise === operation) {
-            initializationPromise = null
-          }
-        })
-        .catch(() => undefined)
-      return operation
-    }
+    lifecycle = new AmqpLifecycleCoordinator({
+      node: me,
+      initialize,
+      close: interruption => amqp.close(interruption),
+      removeEventListeners,
+      clearResources: () => {
+        connection = null
+        channel = null
+      },
+      onInitializationError: (error, _recovering) => handleError(error, me),
+      reconnectInterruption: new Error(
+        'AMQP connection interrupted; reconnecting',
+      ),
+    })
 
-    // call
-    void queueInitialization(this)
+    void lifecycle.start()
   }
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -290,6 +290,14 @@ module.exports = function (RED: NodeRedApp): void {
 
           const vhostSwitchRequired = !amqp.isInitializedForVhost(vhost)
           if (vhostSwitchRequired) {
+            if (!vhostChanged) {
+              clearTimeout(reconnectTimeout)
+              reconnectScheduled = false
+              initializationVersion += 1
+              initializationAbortController?.abort(
+                new Error('AMQP initialization cancelled for virtual host switch'),
+              )
+            }
             removeEventListeners()
             await amqp.setVhost(vhost)
 

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -278,6 +278,9 @@ module.exports = function (RED: NodeRedApp): void {
 
           const vhostSwitchRequired = !amqp.isInitializedForVhost(vhost)
           if (vhostSwitchRequired) {
+            const switchCancellation = new Error(
+              'AMQP virtual host switch was cancelled before publishing',
+            )
             const switched = await lifecycle.replace(
               new Error('AMQP initialization cancelled for virtual host switch'),
               async attempt => {
@@ -291,12 +294,13 @@ module.exports = function (RED: NodeRedApp): void {
               },
             )
             if (!switched || (await stopIfShuttingDown())) {
+              done && done(switchCancellation)
               return
             }
           }
         } catch (e) {
           if (lifecycle.isShuttingDown()) {
-            done && done()
+            done && done(toError(e))
             return
           }
           await handleError(e, me)

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -288,7 +288,8 @@ module.exports = function (RED: NodeRedApp): void {
             return
           }
 
-          if (vhostChanged) {
+          const vhostSwitchRequired = !amqp.isInitializedForVhost(vhost)
+          if (vhostSwitchRequired) {
             removeEventListeners()
             await amqp.setVhost(vhost)
 

--- a/src/nodes/amqp-out.ts
+++ b/src/nodes/amqp-out.ts
@@ -290,16 +290,24 @@ module.exports = function (RED: NodeRedApp): void {
 
           const vhostSwitchRequired = !amqp.isInitializedForVhost(vhost)
           if (vhostSwitchRequired) {
-            if (!vhostChanged) {
-              clearTimeout(reconnectTimeout)
-              reconnectScheduled = false
-              initializationVersion += 1
-              initializationAbortController?.abort(
-                new Error('AMQP initialization cancelled for virtual host switch'),
-              )
-            }
+            clearTimeout(reconnectTimeout)
+            reconnectScheduled = false
+            initializationVersion += 1
+            initializationAbortController?.abort(
+              new Error('AMQP initialization cancelled for virtual host switch'),
+            )
+            const switchAbortController = new AbortController()
+            initializationAbortController = switchAbortController
             removeEventListeners()
-            await amqp.setVhost(vhost)
+            try {
+              await amqp.setVhost(vhost, {
+                signal: switchAbortController.signal,
+              })
+            } finally {
+              if (initializationAbortController === switchAbortController) {
+                initializationAbortController = null
+              }
+            }
 
             if (isShuttingDown && (await stopIfShuttingDown())) {
               return
@@ -313,6 +321,10 @@ module.exports = function (RED: NodeRedApp): void {
             reconnectBackoff.reset()
           }
         } catch (e) {
+          if (isShuttingDown) {
+            done && done()
+            return
+          }
           await handleError(e, me)
           done && done(toError(e))
           return

--- a/src/nodes/flow-close-tracker.ts
+++ b/src/nodes/flow-close-tracker.ts
@@ -1,4 +1,4 @@
-import { NodeRedApp } from 'node-red'
+import { Node, NodeRedApp } from 'node-red'
 
 interface FlowStoppingEvent {
   diff?: {
@@ -9,7 +9,18 @@ interface FlowStoppingEvent {
 
 interface TrackedNode {
   nodeId: string
+  subflowOwnerIds: Set<string>
   terminalClose: boolean
+}
+
+interface RuntimeFlow {
+  TYPE?: string
+  id?: string
+  parent?: RuntimeFlow
+}
+
+type RuntimeNode = Node & {
+  _flow?: RuntimeFlow
 }
 
 interface TrackerState {
@@ -19,21 +30,39 @@ interface TrackerState {
 
 const trackerStates = new WeakMap<object, TrackerState>()
 
-function containsNodeOrSubflowChild(
+function containsNodeOrOwnedSubflow(
   nodeIds: string[] | undefined,
-  nodeId: string,
+  trackedNode: TrackedNode,
 ): boolean {
   return Boolean(
     nodeIds?.some(
       changedNodeId =>
-        nodeId === changedNodeId || nodeId.startsWith(`${changedNodeId}-`),
+        trackedNode.nodeId === changedNodeId ||
+        trackedNode.subflowOwnerIds.has(changedNodeId),
     ),
   )
 }
 
+function getSubflowOwnerIds(node: RuntimeNode): Set<string> {
+  const ownerIds = new Set<string>()
+  const visited = new Set<RuntimeFlow>()
+  let flow: RuntimeFlow | undefined = node._flow
+  while (flow && !visited.has(flow)) {
+    visited.add(flow)
+    if (
+      flow.id &&
+      (flow.TYPE === 'subflow' || flow.TYPE?.startsWith('module:'))
+    ) {
+      ownerIds.add(flow.id)
+    }
+    flow = flow.parent
+  }
+  return ownerIds
+}
+
 export default function trackTerminalClose(
   RED: NodeRedApp,
-  nodeId: string,
+  node: RuntimeNode,
 ): {
   dispose: () => void
   shouldRemoveBindings: (removed: boolean) => boolean
@@ -44,13 +73,13 @@ export default function trackTerminalClose(
     const onFlowsStopping = (event: FlowStoppingEvent): void => {
       for (const trackedNode of nodes.values()) {
         trackedNode.terminalClose ||= Boolean(
-          containsNodeOrSubflowChild(
+          containsNodeOrOwnedSubflow(
             event.diff?.changed,
-            trackedNode.nodeId,
+            trackedNode,
           ) ||
-            containsNodeOrSubflowChild(
+            containsNodeOrOwnedSubflow(
               event.diff?.removed,
-              trackedNode.nodeId,
+              trackedNode,
             ),
         )
       }
@@ -60,8 +89,12 @@ export default function trackTerminalClose(
     RED.events.on('flows:stopping', onFlowsStopping)
   }
 
-  const token = Symbol(nodeId)
-  const trackedNode = { nodeId, terminalClose: false }
+  const token = Symbol(node.id)
+  const trackedNode = {
+    nodeId: node.id,
+    subflowOwnerIds: getSubflowOwnerIds(node),
+    terminalClose: false,
+  }
   state.nodes.set(token, trackedNode)
   let disposed = false
 

--- a/src/nodes/flow-close-tracker.ts
+++ b/src/nodes/flow-close-tracker.ts
@@ -1,0 +1,66 @@
+import { NodeRedApp } from 'node-red'
+
+interface FlowStoppingEvent {
+  diff?: {
+    changed?: string[]
+    removed?: string[]
+  }
+}
+
+interface TrackedNode {
+  nodeId: string
+  terminalClose: boolean
+}
+
+interface TrackerState {
+  nodes: Map<symbol, TrackedNode>
+  onFlowsStopping: (event: FlowStoppingEvent) => void
+}
+
+const trackerStates = new WeakMap<object, TrackerState>()
+
+export default function trackTerminalClose(
+  RED: NodeRedApp,
+  nodeId: string,
+): {
+  dispose: () => void
+  shouldRemoveBindings: (removed: boolean) => boolean
+} {
+  let state = trackerStates.get(RED.events)
+  if (!state) {
+    const nodes = new Map<symbol, TrackedNode>()
+    const onFlowsStopping = (event: FlowStoppingEvent): void => {
+      for (const trackedNode of nodes.values()) {
+        trackedNode.terminalClose ||= Boolean(
+          event.diff?.changed?.includes(trackedNode.nodeId) ||
+            event.diff?.removed?.includes(trackedNode.nodeId),
+        )
+      }
+    }
+    state = { nodes, onFlowsStopping }
+    trackerStates.set(RED.events, state)
+    RED.events.on('flows:stopping', onFlowsStopping)
+  }
+
+  const token = Symbol(nodeId)
+  const trackedNode = { nodeId, terminalClose: false }
+  state.nodes.set(token, trackedNode)
+  let disposed = false
+
+  return {
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      state.nodes.delete(token)
+      if (state.nodes.size === 0) {
+        RED.events.removeListener('flows:stopping', state.onFlowsStopping)
+        if (trackerStates.get(RED.events) === state) {
+          trackerStates.delete(RED.events)
+        }
+      }
+    },
+    shouldRemoveBindings: removed => removed || trackedNode.terminalClose,
+  }
+}

--- a/src/nodes/flow-close-tracker.ts
+++ b/src/nodes/flow-close-tracker.ts
@@ -19,6 +19,18 @@ interface TrackerState {
 
 const trackerStates = new WeakMap<object, TrackerState>()
 
+function containsNodeOrSubflowChild(
+  nodeIds: string[] | undefined,
+  nodeId: string,
+): boolean {
+  return Boolean(
+    nodeIds?.some(
+      changedNodeId =>
+        nodeId === changedNodeId || nodeId.startsWith(`${changedNodeId}-`),
+    ),
+  )
+}
+
 export default function trackTerminalClose(
   RED: NodeRedApp,
   nodeId: string,
@@ -32,8 +44,14 @@ export default function trackTerminalClose(
     const onFlowsStopping = (event: FlowStoppingEvent): void => {
       for (const trackedNode of nodes.values()) {
         trackedNode.terminalClose ||= Boolean(
-          event.diff?.changed?.includes(trackedNode.nodeId) ||
-            event.diff?.removed?.includes(trackedNode.nodeId),
+          containsNodeOrSubflowChild(
+            event.diff?.changed,
+            trackedNode.nodeId,
+          ) ||
+            containsNodeOrSubflowChild(
+              event.diff?.removed,
+              trackedNode.nodeId,
+            ),
         )
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Node } from 'node-red'
-import { ConsumeMessage, MessageProperties } from 'amqplib'
+import { ConsumeMessage, Options } from 'amqplib'
 
 export interface BrokerConfig extends Node {
   host: string
@@ -52,7 +52,7 @@ export interface AmqpConfig {
     queueType: string
     queueArguments?: GenericJsonObject
   }
-  amqpProperties: MessageProperties
+  amqpProperties: Options.Publish
   headers: GenericJsonObject
   outputs?: number
   rpcTimeout?: number
@@ -87,7 +87,7 @@ export interface AmqpOutNodeDefaults {
   exchangeRoutingKey?: string
   exchangeDurable?: boolean
   autoCreateExchangeBindings?: boolean
-  amqpProperties?: MessageProperties | JsonObject | string
+  amqpProperties?: Options.Publish | JsonObject | string
   outputs?: number
   rpcTimeoutMilliseconds?: number
   queueArguments?: JsonObject

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -912,6 +912,12 @@ describe('Amqp Class', () => {
     expect((Amqp as any).connectionPool.size).to.equal(0)
   })
 
+  it('closes safely before owning a connection', async () => {
+    await amqp.close()
+
+    expect((Amqp as any).connectionPool.size).to.equal(0)
+  })
+
   it('initialize()', async () => {
     const createChannelStub = sinon.stub()
     const assertExchangeStub = sinon.stub()
@@ -2841,6 +2847,27 @@ describe('Amqp Class', () => {
   })
 
   describe('setVhost()', () => {
+    it('switches vhost safely while the initial connection is still pending', async () => {
+      const replacementConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub().resolves(),
+        connection: { stream: { destroyed: false } },
+      }
+      const connectStub = sinon.stub(amqplib, 'connect')
+      connectStub.onFirstCall().returns(new Promise(() => undefined))
+      connectStub.onSecondCall().resolves(replacementConnection)
+      const initializeStub = sinon.stub(amqp, 'initialize').resolves({} as any)
+
+      void amqp.connect()
+      await Promise.resolve()
+      await amqp.setVhost('replacement-vhost')
+
+      expect(connectStub.calledTwice).to.be.true
+      expect(initializeStub.calledOnce).to.be.true
+      expect(amqp.getConnection()).to.equal(replacementConnection)
+    })
+
     it('reconnects when vhost changes', async () => {
       amqp.broker = { ...brokerConfigFixture, vhost: 'vh1' }
       const closeStub = sinon.stub(amqp, 'close').resolves()

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -112,6 +112,16 @@ describe('Amqp Class', () => {
     expect(warnStub.called).to.be.false
   })
 
+  it('does not apply the cleanup timeout to a normal connection', async () => {
+    const result = { on: sinon.stub() }
+    const connectStub = sinon.stub(amqplib, 'connect').resolves(result)
+
+    await amqp.connect()
+
+    expect(connectStub.calledOnce).to.be.true
+    expect(connectStub.firstCall.args[1]).to.deep.equal({ heartbeat: 2 })
+  })
+
   it('connect() logs events', async () => {
     const events: { [key: string]: Function } = {}
     const result = { on: (ev: string, cb: Function): void => { events[ev] = cb } }
@@ -1597,11 +1607,54 @@ describe('Amqp Class', () => {
       }
 
       await amqp.close({ removeBindings: true })
-      await amqp.close({ removeBindings: true })
 
       expect(unbindQueueStub.calledTwice).to.be.true
       expect(connectStub.calledOnce).to.be.true
       expect(initializeStub.calledOnce).to.be.true
+    })
+
+    it('fails one terminal close after exhausting binding cleanup retries', async () => {
+      const unbindQueueStub = sinon.stub().rejects(new Error('unbind failed'))
+      const cleanupChannel = { unbindQueue: unbindQueueStub }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+      const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.channel = { unbindQueue: unbindQueueStub }
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      let cleanupError
+      try {
+        await amqp.close({ removeBindings: true })
+      } catch (error) {
+        cleanupError = error
+      }
+
+      expect(String(cleanupError)).to.match(
+        /Could not remove AMQP bindings after 3 attempts/,
+      )
+      expect(unbindQueueStub.callCount).to.equal(3)
+      expect(connectStub.callCount).to.equal(2)
+      expect(initializeStub.callCount).to.equal(2)
+      expect(closeChannelStub.callCount).to.equal(3)
+      expect(releaseConnectionStub.callCount).to.equal(3)
     })
 
     it('reopens resources to remove durable bindings after reconnect already closed them', async () => {
@@ -1677,7 +1730,6 @@ describe('Amqp Class', () => {
       }
 
       await amqp.close()
-      await amqp.close({ removeBindings: true })
       await amqp.close({ removeBindings: true })
 
       expect(unbindQueueStub.calledTwice).to.be.true
@@ -2417,7 +2469,7 @@ describe('Amqp Class', () => {
         });
         await clock.tickAsync(0);
 
-        await clock.tickAsync(5000);
+        await clock.tickAsync(500);
         const timedOutBeforePublish = sendStub.called;
         const deletedBeforePublish = deleteQueueStub.called;
         const publishCountBeforeDrain = channel.publish.callCount;
@@ -2436,6 +2488,61 @@ describe('Amqp Class', () => {
         expect(timedOutBeforeFullPublishedInterval).to.be.false;
         expect(sendStub.calledOnce).to.be.true;
         expect(deleteQueueStub.calledOnce).to.be.true;
+    });
+
+    it('cancels an RPC write that exceeds the backpressure admission deadline', async () => {
+        const { EventEmitter } = require('events');
+        const sendStub = sinon.stub();
+        const deleteQueueStub = sinon.stub().resolves();
+        const channel = new EventEmitter();
+        channel.assertQueue = sinon.stub().resolves('rpc-queue');
+        channel.consume = sinon.stub().resolves({ consumerTag: 'rpc-consumer' });
+        channel.deleteQueue = deleteQueueStub;
+        channel.publish = sinon.stub();
+        channel.publish.onFirstCall().returns(false);
+        channel.publish.onSecondCall().returns(true);
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub() };
+        amqp.channel = channel;
+        amqp.config.outputs = 0;
+
+        const saturatedPublish = amqp.publish('fill write buffer');
+        await clock.tickAsync(0);
+
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+        let admissionError;
+        let rpcSettled = false;
+        const rpcPublish = amqp.publish('must not execute remotely', {
+            correlationId: 'rpc-admission-timeout',
+            replyTo: 'rpc-queue',
+        }).then(
+            () => {
+                rpcSettled = true;
+            },
+            error => {
+                admissionError = error;
+                rpcSettled = true;
+            },
+        );
+
+        amqp.config.outputs = 0;
+        const laterPublish = amqp.publish('publish after cancelled RPC');
+        await clock.tickAsync(1001);
+
+        expect(rpcSettled).to.be.true;
+        expect(String(admissionError)).to.match(/waiting to publish RPC request/);
+        expect(channel.publish.calledOnce).to.be.true;
+        expect(sendStub.called).to.be.false;
+        expect(deleteQueueStub.calledOnce).to.be.true;
+
+        channel.emit('drain');
+        await Promise.all([saturatedPublish, rpcPublish, laterPublish]);
+
+        expect(channel.publish.callCount).to.equal(2);
+        expect(channel.publish.secondCall.args[2].toString()).to.equal(
+            'publish after cancelled RPC',
+        );
     });
 
     it('handles RPC timeout with mismatched correlation ID message', async () => {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -27,6 +27,8 @@ describe('Amqp Class', () => {
     }
 
     ;(Amqp as any).connectionPool.clear()
+    ;(Amqp as any).pendingConnections.clear()
+    ;(Amqp as any).endpointGenerations.clear()
 
     // @ts-ignore
     amqp = new Amqp(RED, nodeFixture, nodeConfigFixture)
@@ -490,6 +492,103 @@ describe('Amqp Class', () => {
     } finally {
       clock.restore()
     }
+  })
+
+  it('closes a connection that resolves after its last waiter timed out', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let resolveConnect: (connection: unknown) => void = () => undefined
+      const lateConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub().resolves(),
+        connection: { stream: { destroyed: false } },
+      }
+      sinon.stub(amqplib, 'connect').returns(
+        new Promise(resolve => {
+          resolveConnect = resolve
+        }),
+      )
+
+      const result = amqp.connect({ timeout: 5_000 }).then(
+        () => 'connected',
+        (error: Error) => error.message,
+      )
+      await clock.tickAsync(5_001)
+
+      expect(await result).to.match(/timed out/i)
+      resolveConnect(lateConnection)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(lateConnection.close.calledOnce).to.be.true
+      expect((Amqp as any).connectionPool.size).to.equal(0)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('does not share a pending connection across broker endpoint generations', async () => {
+    let resolveOld: (connection: unknown) => void = () => undefined
+    let resolveNew: (connection: unknown) => void = () => undefined
+    const oldConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+      connection: { stream: { destroyed: false } },
+    }
+    const newConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+      connection: { stream: { destroyed: false } },
+    }
+    const connectStub = sinon.stub(amqplib, 'connect')
+    connectStub.onFirstCall().returns(
+      new Promise(resolve => {
+        resolveOld = resolve
+      }),
+    )
+    connectStub.onSecondCall().returns(
+      new Promise(resolve => {
+        resolveNew = resolve
+      }),
+    )
+    const broker = { ...brokerConfigFixture, vhost: 'vh1' }
+    RED.nodes.getNode.returns(broker)
+    const oldAmqp: any = new Amqp(
+      RED,
+      { ...nodeFixture, id: 'old' },
+      nodeConfigFixture,
+    )
+    const newAmqp: any = new Amqp(
+      RED,
+      { ...nodeFixture, id: 'new' },
+      nodeConfigFixture,
+    )
+
+    const oldAttempt = oldAmqp.connect()
+    broker.host = 'replacement-host'
+    broker.credentials = {
+      ...broker.credentials,
+      password: 'replacement-password',
+    }
+    const newAttempt = newAmqp.connect()
+
+    expect(connectStub.calledTwice).to.be.true
+    expect(connectStub.firstCall.args[0]).to.not.equal(
+      connectStub.secondCall.args[0],
+    )
+
+    resolveOld(oldConnection)
+    resolveNew(newConnection)
+    expect(await oldAttempt).to.equal(oldConnection)
+    expect(await newAttempt).to.equal(newConnection)
+
+    await oldAmqp.close()
+    await newAmqp.close()
+    expect(oldConnection.close.calledOnce).to.be.true
+    expect(newConnection.close.calledOnce).to.be.true
   })
 
   it('shares one connection but uses separate channels for manual-ack input and output instances', async () => {
@@ -1951,7 +2050,7 @@ describe('Amqp Class', () => {
       expect(releaseConnectionStub.calledThrice).to.be.true
     })
 
-    it('bounds a cleanup-only reconnect when the broker does not respond', async () => {
+    it('uses one overall cleanup budget when the broker does not respond', async () => {
       const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
       try {
         const connectStub = sinon
@@ -2000,11 +2099,11 @@ describe('Amqp Class', () => {
         expect(cleanupSettled).to.be.false
         expect(connectStub.firstCall.args[1]).to.deep.equal({ heartbeat: 2 })
 
-        await clock.tickAsync(10_002)
-        await cleanup
+        await clock.tickAsync(2)
 
         expect(cleanupSettled).to.be.true
         expect(connectStub.calledOnce).to.be.true
+        await cleanup
       } finally {
         clock.restore()
       }

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -5,13 +5,14 @@ const { expect } = require('chai')
 const { NODE_STATUS } = require('../src/constants')
 const sinon = require('sinon')
 const amqplib = require('amqplib')
+const { util: redUtil } = require('@node-red/util')
 const Amqp = require('../src/Amqp').default
 const {
   nodeConfigFixture,
   nodeFixture,
   brokerConfigFixture,
 } = require('./doubles')
-const { ExchangeType, DefaultExchangeName } = require('../src/types')
+const { ExchangeType, DefaultExchangeName, NodeType } = require('../src/types')
 import type { GenericJsonObject, BrokerConfig } from '../src/types'
 
 let RED: any
@@ -334,6 +335,238 @@ describe('Amqp Class', () => {
 
     await amqp2.close()
     expect(connectionStub.close.calledOnce).to.be.true
+  })
+
+  it('shares one connection when instances connect concurrently for the same vhost', async () => {
+    let releaseConnect: () => void = () => undefined
+    const connectPending = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+    const connectionStub = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+      connection: { stream: { destroyed: false } },
+    }
+    const connectStub = sinon.stub(amqplib, 'connect').callsFake(async () => {
+      await connectPending
+      return connectionStub as any
+    })
+    const broker = { ...brokerConfigFixture, vhost: 'vh1' }
+    RED.nodes.getNode.returns(broker)
+
+    const amqp1: any = new Amqp(
+      RED,
+      { ...nodeFixture, id: 'n1' },
+      nodeConfigFixture,
+    )
+    const amqp2: any = new Amqp(
+      RED,
+      { ...nodeFixture, id: 'n2' },
+      nodeConfigFixture,
+    )
+
+    const firstConnection = amqp1.connect()
+    const secondConnection = amqp2.connect()
+    await Promise.resolve()
+    releaseConnect()
+
+    const connections = await Promise.all([firstConnection, secondConnection])
+    const poolEntry = (Amqp as any).connectionPool.get('b1:vh1')
+
+    expect(connectStub.calledOnce).to.be.true
+    expect(connections).to.deep.equal([connectionStub, connectionStub])
+    expect(poolEntry.connection).to.equal(connectionStub)
+    expect(poolEntry.count).to.equal(2)
+
+    await amqp1.close()
+    expect(connectionStub.close.called).to.be.false
+
+    await amqp2.close()
+    expect(connectionStub.close.calledOnce).to.be.true
+  })
+
+  it('shares one connection but uses separate channels for manual-ack input and output instances', async () => {
+    const manualAckChannel = {
+      prefetch: sinon.stub(),
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+    }
+    const outputChannel = {
+      prefetch: sinon.stub(),
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+    }
+    const createChannelStub = sinon.stub()
+    createChannelStub.onFirstCall().resolves(manualAckChannel)
+    createChannelStub.onSecondCall().resolves(outputChannel)
+    const connectionStub = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub().resolves(),
+      createChannel: createChannelStub,
+      connection: { stream: { destroyed: false } },
+    }
+    const connectStub = sinon
+      .stub(amqplib, 'connect')
+      .resolves(connectionStub as any)
+    const manualAckAmqp: any = new Amqp(
+      RED,
+      {
+        ...nodeFixture,
+        id: 'manual-in',
+        type: NodeType.AmqpInManualAck,
+      },
+      nodeConfigFixture,
+    )
+    const outputAmqp: any = new Amqp(
+      RED,
+      {
+        ...nodeFixture,
+        id: 'out',
+        type: NodeType.AmqpOut,
+      },
+      nodeConfigFixture,
+    )
+
+    await Promise.all([manualAckAmqp.connect(), outputAmqp.connect()])
+    const channels = await Promise.all([
+      manualAckAmqp.initialize(),
+      outputAmqp.initialize(),
+    ])
+
+    expect(connectStub.calledOnce).to.be.true
+    expect(channels).to.deep.equal([manualAckChannel, outputChannel])
+    expect(createChannelStub.calledTwice).to.be.true
+
+    await manualAckAmqp.close()
+    expect(manualAckChannel.close.calledOnce).to.be.true
+    expect(outputChannel.close.called).to.be.false
+    expect(connectionStub.close.called).to.be.false
+
+    await outputAmqp.close()
+    expect(outputChannel.close.calledOnce).to.be.true
+    expect(connectionStub.close.calledOnce).to.be.true
+  })
+
+  it('acknowledges the original delivery after Node-RED clones the message', () => {
+    const node = {
+      ...nodeFixture,
+      id: 'manual-in',
+      type: NodeType.AmqpInManualAck,
+      error: sinon.stub(),
+    }
+    const manualAckAmqp: any = new Amqp(RED, node, nodeConfigFixture)
+    const channel = { ack: sinon.stub() }
+    manualAckAmqp.channel = channel
+    const delivery = manualAckAmqp.assembleMessage({
+      content: Buffer.from('payload'),
+      fields: { deliveryTag: 42 },
+      properties: {},
+    })
+    const clonedDelivery = redUtil.cloneMessage(delivery)
+
+    manualAckAmqp.ack(clonedDelivery)
+
+    expect(clonedDelivery).to.not.equal(delivery)
+    expect(channel.ack.calledOnceWith(delivery, false)).to.be.true
+  })
+
+  it('does not settle a pre-restart delivery on the replacement channel', () => {
+    const node = {
+      ...nodeFixture,
+      id: 'manual-in',
+      type: NodeType.AmqpInManualAck,
+      error: sinon.stub(),
+    }
+    const manualAckAmqp: any = new Amqp(RED, node, nodeConfigFixture)
+    const originalChannel = {
+      ack: sinon.stub(),
+      ackAll: sinon.stub(),
+      nack: sinon.stub(),
+      nackAll: sinon.stub(),
+      reject: sinon.stub(),
+    }
+    const replacementChannel = {
+      ack: sinon.stub(),
+      ackAll: sinon.stub(),
+      nack: sinon.stub(),
+      nackAll: sinon.stub(),
+      reject: sinon.stub(),
+    }
+    manualAckAmqp.channel = originalChannel
+    const delivery = manualAckAmqp.assembleMessage({
+      content: Buffer.from('payload'),
+      fields: { deliveryTag: 42 },
+      properties: {},
+    })
+
+    manualAckAmqp.channel = replacementChannel
+    manualAckAmqp.ack(delivery)
+    manualAckAmqp.ackAll(delivery)
+    manualAckAmqp.nack(delivery)
+    manualAckAmqp.nackAll(delivery)
+    manualAckAmqp.reject(delivery)
+
+    expect(originalChannel.ack.called).to.be.false
+    expect(originalChannel.ackAll.called).to.be.false
+    expect(originalChannel.nack.called).to.be.false
+    expect(originalChannel.nackAll.called).to.be.false
+    expect(originalChannel.reject.called).to.be.false
+    expect(replacementChannel.ack.called).to.be.false
+    expect(replacementChannel.ackAll.called).to.be.false
+    expect(replacementChannel.nack.called).to.be.false
+    expect(replacementChannel.nackAll.called).to.be.false
+    expect(replacementChannel.reject.called).to.be.false
+  })
+
+  it('does not acknowledge the same manual delivery twice', () => {
+    const node = {
+      ...nodeFixture,
+      id: 'manual-in',
+      type: NodeType.AmqpInManualAck,
+      error: sinon.stub(),
+    }
+    const manualAckAmqp: any = new Amqp(RED, node, nodeConfigFixture)
+    const channel = { ack: sinon.stub() }
+    manualAckAmqp.channel = channel
+    const delivery = manualAckAmqp.assembleMessage({
+      content: Buffer.from('payload'),
+      fields: { deliveryTag: 42 },
+      properties: {},
+    })
+
+    manualAckAmqp.ack(delivery)
+    manualAckAmqp.ack(delivery)
+
+    expect(channel.ack.calledOnce).to.be.true
+    expect(node.error.calledWithMatch('active AMQP channel')).to.be.true
+  })
+
+  it('reports a failed manual acknowledgement when the channel rejects it', () => {
+    const node = {
+      ...nodeFixture,
+      id: 'manual-in',
+      type: NodeType.AmqpInManualAck,
+      error: sinon.stub(),
+    }
+    const manualAckAmqp: any = new Amqp(RED, node, nodeConfigFixture)
+    const channel = {
+      ack: sinon.stub().throws(new Error('channel is closed')),
+    }
+    manualAckAmqp.channel = channel
+    const delivery = manualAckAmqp.assembleMessage({
+      content: Buffer.from('payload'),
+      fields: { deliveryTag: 42 },
+      properties: {},
+    })
+
+    const acknowledged = manualAckAmqp.ack(delivery)
+
+    expect(acknowledged).to.equal(false)
+    expect(node.error.calledWithMatch('channel is closed')).to.be.true
   })
 
   it('does not reuse a dead pooled connection', async () => {
@@ -812,6 +1045,127 @@ describe('Amqp Class', () => {
       expect(waitForConfirmsStub.calledOnce).to.equal(true)
     })
 
+    it('waits for channel drain when publish applies backpressure', async () => {
+      const { EventEmitter } = require('events')
+      const channel = new EventEmitter()
+      channel.publish = sinon.stub().returns(false)
+      amqp.channel = channel
+
+      let completed = false
+      const publishPromise = amqp.publish('a message').then(() => {
+        completed = true
+      })
+      await new Promise(resolve => setImmediate(resolve))
+
+      expect(completed).to.equal(false)
+
+      channel.emit('drain')
+      await publishPromise
+      expect(completed).to.equal(true)
+    })
+
+    it('rejects a confirmed publish when the broker returns a mandatory message', async () => {
+      const events: Record<string, (message?: unknown) => void> = {}
+      let releaseConfirm: () => void = () => undefined
+      const confirmPending = new Promise<void>(resolve => {
+        releaseConfirm = resolve
+      })
+      const channel = {
+        on: sinon.stub().callsFake(
+          (event: string, callback: (message?: unknown) => void) => {
+            events[event] = callback
+          },
+        ),
+        prefetch: sinon.stub().resolves(),
+        publish: sinon.stub().returns(true),
+        waitForConfirms: sinon.stub().returns(confirmPending),
+      }
+      amqp.connection = {
+        createConfirmChannel: sinon.stub().resolves(channel),
+      }
+      amqp.config.waitForConfirms = true
+      await amqp.initialize()
+
+      const publishResult = amqp
+        .publish('a message', {
+          mandatory: true,
+          messageId: 'returned-message',
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        )
+      await Promise.resolve()
+
+      const publishedOptions = channel.publish.firstCall.args[3]
+      events.return({
+        fields: {
+          replyCode: 312,
+          replyText: 'NO_ROUTE',
+          exchange: 'events',
+          routingKey: 'missing.route',
+        },
+        properties: publishedOptions,
+        content: Buffer.from('a message'),
+      })
+      releaseConfirm()
+
+      const publishError = await publishResult
+      expect(publishError).to.be.instanceOf(Error)
+    })
+
+    it('reports successful and failed routing keys after partial mandatory delivery', async () => {
+      const events: Record<string, (message?: unknown) => void> = {}
+      const channel = {
+        on: sinon.stub().callsFake(
+          (event: string, callback: (message?: unknown) => void) => {
+            events[event] = callback
+          },
+        ),
+        prefetch: sinon.stub().resolves(),
+        publish: sinon.stub().callsFake(
+          (
+            exchange: string,
+            routingKey: string,
+            content: Buffer,
+            options: unknown,
+          ) => {
+            if (routingKey === 'route.missing') {
+              events.return({
+                fields: {
+                  replyCode: 312,
+                  replyText: 'NO_ROUTE',
+                  exchange,
+                  routingKey,
+                },
+                properties: options,
+                content,
+              })
+            }
+            return true
+          },
+        ),
+        waitForConfirms: sinon.stub().resolves(),
+      }
+      amqp.connection = {
+        createConfirmChannel: sinon.stub().resolves(channel),
+      }
+      amqp.config.exchange.routingKey = 'route.ok,route.missing'
+      amqp.config.waitForConfirms = true
+      await amqp.initialize()
+
+      const publishError = await amqp
+        .publish('a message', { mandatory: true })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        )
+
+      expect(publishError).to.be.instanceOf(Error)
+      expect(publishError.successfulRoutingKeys).to.deep.equal(['route.ok'])
+      expect(publishError.failedRoutingKeys).to.deep.equal(['route.missing'])
+    })
+
     it('tries to publish an invalid message', async () => {
       const publishStub = sinon.stub().throws()
       const errorStub = sinon.stub()
@@ -1207,7 +1561,15 @@ describe('Amqp Class', () => {
     await amqp.createChannel()
 
     events['close']()
-    events['return']()
+    events['return']({
+      fields: {
+        replyCode: 312,
+        replyText: 'NO_ROUTE',
+        exchange: 'events',
+        routingKey: 'missing.route',
+      },
+      properties: { headers: {} },
+    })
     events['error']('oops')
 
     expect(logStub.calledWithMatch('AMQP Channel closed')).to.be.true
@@ -1586,6 +1948,141 @@ describe('Amqp Class', () => {
         expect(deleteQueueStub.calledOnce).to.be.true;
     });
 
+    it('does not lose concurrent RPC responses that share a reply queue', async () => {
+        const sendStub = sinon.stub();
+        const deleteQueueStub = sinon.stub().resolves();
+        const assertQueueStub = sinon.stub().resolves('shared-reply-queue');
+        const consumeCallbacks: Array<(message: unknown) => void> = [];
+        const consumeStub = sinon.stub().callsFake((queue, callback) => {
+            consumeCallbacks.push(callback);
+            return Promise.resolve({ consumerTag: `consumer-${consumeCallbacks.length}` });
+        });
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub() };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            publish: sinon.stub(),
+        };
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+
+        await Promise.all([
+            amqp.publish('request-one', {
+                correlationId: 'correlation-one',
+                replyTo: 'shared-reply-queue',
+            }),
+            amqp.publish('request-two', {
+                correlationId: 'correlation-two',
+                replyTo: 'shared-reply-queue',
+            }),
+        ]);
+
+        expect(consumeStub.calledOnce).to.equal(true);
+
+        const sharedConsumer = consumeCallbacks[0];
+        sharedConsumer({
+            fields: { deliveryTag: 1 },
+            properties: { correlationId: 'correlation-two' },
+            content: Buffer.from('{"response":2}'),
+        });
+        sharedConsumer({
+            fields: { deliveryTag: 2 },
+            properties: { correlationId: 'correlation-one' },
+            content: Buffer.from('{"response":1}'),
+        });
+        await Promise.resolve();
+
+        expect(sendStub.callCount).to.equal(2);
+        expect(sendStub.getCalls().map(call => call.args[0].payload)).to.deep.equal([
+            { response: 2 },
+            { response: 1 },
+        ]);
+    });
+
+    it('does not lose RPC responses when separate instances share a reply queue', async () => {
+        const firstSendStub = sinon.stub();
+        const secondSendStub = sinon.stub();
+        const firstCallbacks: Array<(message: unknown) => void> = [];
+        const secondCallbacks: Array<(message: unknown) => void> = [];
+        const firstDeleteQueueStub = sinon.stub().resolves();
+        const secondDeleteQueueStub = sinon.stub().resolves();
+        const sharedConnection = {};
+
+        const secondAmqp: any = new Amqp(
+            RED,
+            { ...nodeFixture, id: 'rpc-node-two', send: secondSendStub, error: sinon.stub() },
+            nodeConfigFixture,
+        );
+        amqp.node = {
+            ...nodeFixture,
+            id: 'rpc-node-one',
+            send: firstSendStub,
+            error: sinon.stub(),
+        };
+        amqp.connection = sharedConnection;
+        secondAmqp.connection = sharedConnection;
+        amqp.channel = {
+            assertQueue: sinon.stub().resolves('shared-reply-queue'),
+            consume: sinon.stub().callsFake((queue, callback) => {
+                firstCallbacks.push(callback);
+                return Promise.resolve({ consumerTag: 'consumer-one' });
+            }),
+            deleteQueue: firstDeleteQueueStub,
+            publish: sinon.stub(),
+        };
+        secondAmqp.channel = {
+            assertQueue: sinon.stub().resolves('shared-reply-queue'),
+            consume: sinon.stub().callsFake((queue, callback) => {
+                secondCallbacks.push(callback);
+                return Promise.resolve({ consumerTag: 'consumer-two' });
+            }),
+            deleteQueue: secondDeleteQueueStub,
+            publish: sinon.stub(),
+        };
+        amqp.config.outputs = 1;
+        secondAmqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+        secondAmqp.config.rpcTimeout = 1000;
+
+        await Promise.all([
+            amqp.publish('request-one', {
+                correlationId: 'correlation-one',
+                replyTo: 'shared-reply-queue',
+            }),
+            secondAmqp.publish('request-two', {
+                correlationId: 'correlation-two',
+                replyTo: 'shared-reply-queue',
+            }),
+        ]);
+
+        const brokerSelectedConsumer = firstCallbacks[0];
+        brokerSelectedConsumer({
+            fields: { deliveryTag: 1 },
+            properties: { correlationId: 'correlation-one' },
+            content: Buffer.from('{"response":1}'),
+        });
+        await Promise.resolve();
+
+        expect(firstDeleteQueueStub.called).to.equal(false);
+        expect(secondDeleteQueueStub.called).to.equal(false);
+
+        brokerSelectedConsumer({
+            fields: { deliveryTag: 2 },
+            properties: { correlationId: 'correlation-two' },
+            content: Buffer.from('{"response":2}'),
+        });
+        await Promise.resolve();
+
+        expect(firstSendStub.calledOnce).to.equal(true);
+        expect(secondSendStub.calledOnce).to.equal(true);
+        expect(secondSendStub.firstCall.args[0].payload).to.deep.equal({
+            response: 2,
+        });
+        expect(secondCallbacks).to.have.length(0);
+    });
+
     it('handles error when deleting queue on timeout', async () => {
         const sendStub = sinon.stub();
         const deleteQueueStub = sinon.stub().rejects(new Error('delete failed'));
@@ -1727,6 +2224,39 @@ describe('Amqp Class', () => {
 
         expect(sendStub.called).to.be.false;
         expect(deleteQueueStub.called).to.be.false;
+    });
+
+    it('reports an in-flight RPC as failed when reconnect closes its channel', async () => {
+        const sendStub = sinon.stub();
+        const poolConnection = {
+            close: sinon.stub().resolves(),
+            off: sinon.stub(),
+        };
+
+        sinon.stub(amqp, 'assertQueue').resolves('rpc-queue');
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub(), status: sinon.stub() };
+        amqp.channel = {
+            consume: sinon.stub().resolves({ consumerTag: 'rpc-consumer' }),
+            deleteQueue: sinon.stub().resolves(),
+            publish: sinon.stub(),
+            off: sinon.stub(),
+            close: sinon.stub().resolves(),
+        };
+        amqp.connection = poolConnection;
+        amqp.broker = { ...brokerConfigFixture, vhost: 'vh1', id: 'b1' };
+        (Amqp as any).connectionPool.set('b1:vh1', { connection: poolConnection, count: 1 });
+
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+
+        await amqp.publish('a message');
+        await amqp.close(new Error('AMQP connection lost during RPC'));
+
+        expect(sendStub.calledOnce).to.be.true;
+        expect(sendStub.firstCall.args[0].payload.message).to.match(
+            /connection lost|interrupted/i,
+        );
     });
 
     it('handles error during RPC setup', async () => {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -2083,6 +2083,76 @@ describe('Amqp Class', () => {
         expect(secondCallbacks).to.have.length(0);
     });
 
+    it('waits for shared RPC consumer cleanup before recreating its reply queue', async () => {
+        let finishDeleteQueue: () => void = () => undefined;
+        const deleteQueuePending = new Promise<void>(resolve => {
+            finishDeleteQueue = resolve;
+        });
+        const firstCallbacks: Array<(message: unknown) => void> = [];
+        const sharedConnection = {};
+        const secondAmqp: any = new Amqp(
+            RED,
+            { ...nodeFixture, id: 'rpc-node-two', send: sinon.stub(), error: sinon.stub() },
+            nodeConfigFixture,
+        );
+
+        amqp.node = {
+            ...nodeFixture,
+            id: 'rpc-node-one',
+            send: sinon.stub(),
+            error: sinon.stub(),
+        };
+        amqp.connection = sharedConnection;
+        secondAmqp.connection = sharedConnection;
+        amqp.channel = {
+            assertQueue: sinon.stub().resolves('shared-reply-queue'),
+            consume: sinon.stub().callsFake((queue, callback) => {
+                firstCallbacks.push(callback);
+                return Promise.resolve({ consumerTag: 'consumer-one' });
+            }),
+            deleteQueue: sinon.stub().returns(deleteQueuePending),
+            publish: sinon.stub(),
+        };
+        const secondConsumeStub = sinon.stub().resolves({
+            consumerTag: 'consumer-two',
+        });
+        amqp.config.outputs = 1;
+        secondAmqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+        secondAmqp.config.rpcTimeout = 1000;
+        secondAmqp.channel = {
+            assertQueue: sinon.stub().resolves('shared-reply-queue'),
+            consume: secondConsumeStub,
+            deleteQueue: sinon.stub().resolves(),
+            publish: sinon.stub(),
+        };
+
+        await amqp.publish('request-one', {
+            correlationId: 'correlation-one',
+            replyTo: 'shared-reply-queue',
+        });
+        firstCallbacks[0]({
+            fields: { deliveryTag: 1 },
+            properties: { correlationId: 'correlation-one' },
+            content: Buffer.from('{"response":1}'),
+        });
+        await Promise.resolve();
+
+        const secondPublish = secondAmqp.publish('request-two', {
+            correlationId: 'correlation-two',
+            replyTo: 'shared-reply-queue',
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(secondConsumeStub.called).to.equal(false);
+
+        finishDeleteQueue();
+        await secondPublish;
+
+        expect(secondConsumeStub.calledOnce).to.equal(true);
+    });
+
     it('handles error when deleting queue on timeout', async () => {
         const sendStub = sinon.stub();
         const deleteQueueStub = sinon.stub().rejects(new Error('delete failed'));

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -1567,6 +1567,43 @@ describe('Amqp Class', () => {
       expect(releaseConnectionStub.calledOnce).to.be.true
     })
 
+    it('retries binding cleanup when the active-channel unbind fails', async () => {
+      const unbindQueueStub = sinon.stub()
+      unbindQueueStub.onFirstCall().rejects(new Error('unbind failed'))
+      unbindQueueStub.onSecondCall().resolves()
+      const cleanupChannel = { unbindQueue: unbindQueueStub }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      sinon.stub(amqp, 'closeChannel' as any).resolves()
+      sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.channel = { unbindQueue: unbindQueueStub }
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close({ removeBindings: true })
+      await amqp.close({ removeBindings: true })
+
+      expect(unbindQueueStub.calledTwice).to.be.true
+      expect(connectStub.calledOnce).to.be.true
+      expect(initializeStub.calledOnce).to.be.true
+    })
+
     it('reopens resources to remove durable bindings after reconnect already closed them', async () => {
       const unbindQueueStub = sinon.stub().resolves()
       const cleanupChannel = {
@@ -1609,6 +1646,101 @@ describe('Amqp Class', () => {
       ).to.be.true
       expect(closeChannelStub.calledTwice).to.be.true
       expect(releaseConnectionStub.calledTwice).to.be.true
+    })
+
+    it('retries binding cleanup when a reopened-channel unbind fails', async () => {
+      const unbindQueueStub = sinon.stub()
+      unbindQueueStub.onFirstCall().rejects(new Error('unbind failed'))
+      unbindQueueStub.onSecondCall().resolves()
+      const cleanupChannel = { unbindQueue: unbindQueueStub }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      sinon.stub(amqp, 'closeChannel' as any).resolves()
+      sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close()
+      await amqp.close({ removeBindings: true })
+      await amqp.close({ removeBindings: true })
+
+      expect(unbindQueueStub.calledTwice).to.be.true
+      expect(connectStub.calledTwice).to.be.true
+      expect(initializeStub.calledTwice).to.be.true
+    })
+
+    it('bounds a cleanup-only reconnect when the broker does not respond', async () => {
+      const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+      try {
+        const connectStub = sinon
+          .stub(amqplib, 'connect')
+          .callsFake(
+            (_url: string, socketOptions: { timeout?: number }) =>
+              new Promise((_resolve, reject) => {
+                if (socketOptions.timeout) {
+                  setTimeout(
+                    () => reject(new Error('connect ETIMEDOUT')),
+                    socketOptions.timeout,
+                  )
+                }
+              }),
+          )
+        sinon.stub(amqp, 'closeChannel' as any).resolves()
+        sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+        amqp.q = { queue: 'orders' }
+        amqp.config.exchange = {
+          ...amqp.config.exchange,
+          autoCreate: true,
+          name: 'orders-exchange',
+          routingKey: 'orders.v1',
+        }
+        amqp.config.queue = {
+          ...amqp.config.queue,
+          name: 'orders',
+          durable: true,
+          exclusive: false,
+          autoDelete: false,
+        }
+
+        await amqp.close()
+        let cleanupSettled = false
+        const cleanup = amqp.close({ removeBindings: true }).then(
+          () => {
+            cleanupSettled = true
+          },
+          () => {
+            cleanupSettled = true
+          },
+        )
+        await clock.tickAsync(4_999)
+
+        expect(cleanupSettled).to.be.false
+        expect(connectStub.firstCall.args[1].timeout).to.equal(5_000)
+
+        await clock.tickAsync(2)
+        await cleanup
+
+        expect(cleanupSettled).to.be.true
+      } finally {
+        clock.restore()
+      }
     })
   })
 
@@ -2252,6 +2384,57 @@ describe('Amqp Class', () => {
 
         expect(sendStub.calledOnce).to.be.true;
         expect(sendStub.firstCall.args[0].payload.message).to.match(/Timeout while waiting for RPC response/);
+        expect(deleteQueueStub.calledOnce).to.be.true;
+    });
+
+    it('starts the RPC timeout only after a backpressured request is published', async () => {
+        const { EventEmitter } = require('events');
+        const sendStub = sinon.stub();
+        const deleteQueueStub = sinon.stub().resolves();
+        const assertQueueStub = sinon.stub().resolves('rpc-queue');
+        const consumeStub = sinon.stub().resolves({ consumerTag: 'rpc-consumer' });
+        const channel = new EventEmitter();
+        channel.assertQueue = assertQueueStub;
+        channel.consume = consumeStub;
+        channel.deleteQueue = deleteQueueStub;
+        channel.publish = sinon.stub();
+        channel.publish.onFirstCall().returns(false);
+        channel.publish.onSecondCall().returns(true);
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub() };
+        amqp.channel = channel;
+        amqp.config.outputs = 0;
+
+        const saturatedPublish = amqp.publish('fill write buffer');
+        await clock.tickAsync(0);
+        expect(channel.publish.calledOnce).to.be.true;
+
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+        const rpcPublish = amqp.publish('execute once', {
+            correlationId: 'rpc-after-drain',
+            replyTo: 'rpc-queue',
+        });
+        await clock.tickAsync(0);
+
+        await clock.tickAsync(5000);
+        const timedOutBeforePublish = sendStub.called;
+        const deletedBeforePublish = deleteQueueStub.called;
+        const publishCountBeforeDrain = channel.publish.callCount;
+
+        channel.emit('drain');
+        await Promise.all([saturatedPublish, rpcPublish]);
+        expect(channel.publish.callCount).to.equal(2);
+
+        await clock.tickAsync(999);
+        const timedOutBeforeFullPublishedInterval = sendStub.called;
+        await clock.tickAsync(2);
+
+        expect(timedOutBeforePublish).to.be.false;
+        expect(deletedBeforePublish).to.be.false;
+        expect(publishCountBeforeDrain).to.equal(1);
+        expect(timedOutBeforeFullPublishedInterval).to.be.false;
+        expect(sendStub.calledOnce).to.be.true;
         expect(deleteQueueStub.calledOnce).to.be.true;
     });
 

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -528,6 +528,42 @@ describe('Amqp Class', () => {
     }
   })
 
+  it('allows a fresh connection attempt after the final waiter times out', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const replacementConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub().resolves(),
+        connection: { stream: { destroyed: false } },
+      }
+      const connectStub = sinon.stub(amqplib, 'connect')
+      connectStub.onFirstCall().returns(new Promise(() => undefined))
+      connectStub.onSecondCall().resolves(replacementConnection)
+
+      const timedOutResult = amqp.connect({ timeout: 10 }).then(
+        () => 'connected',
+        (error: Error) => error.message,
+      )
+      await clock.tickAsync(11)
+
+      expect(await timedOutResult).to.match(/timed out/i)
+      expect((Amqp as any).pendingConnections.size).to.equal(0)
+
+      const replacementAmqp: any = new Amqp(
+        RED,
+        { ...nodeFixture, id: 'replacement' },
+        nodeConfigFixture,
+      )
+      expect(await replacementAmqp.connect()).to.equal(replacementConnection)
+      expect(connectStub.calledTwice).to.be.true
+
+      await replacementAmqp.close()
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('does not share a pending connection across broker endpoint generations', async () => {
     let resolveOld: (connection: unknown) => void = () => undefined
     let resolveNew: (connection: unknown) => void = () => undefined
@@ -2104,6 +2140,144 @@ describe('Amqp Class', () => {
         expect(cleanupSettled).to.be.true
         expect(connectStub.calledOnce).to.be.true
         await cleanup
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('applies the cleanup budget to the initial active-channel unbind', async () => {
+      const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+      try {
+        const unbindQueueStub = sinon.stub().returns(new Promise(() => undefined))
+        const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+        const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+        amqp.channel = { unbindQueue: unbindQueueStub }
+        amqp.q = { queue: 'orders' }
+        amqp.config.exchange = {
+          ...amqp.config.exchange,
+          autoCreate: true,
+          name: 'orders-exchange',
+          routingKey: 'orders.v1',
+        }
+
+        let closeSettled = false
+        const close = amqp.close({ removeBindings: true }).then(
+          () => {
+            closeSettled = true
+          },
+          () => {
+            closeSettled = true
+          },
+        )
+        await clock.tickAsync(4_999)
+        expect(closeSettled).to.be.false
+
+        await clock.tickAsync(2)
+        expect(closeSettled).to.be.true
+        expect(closeChannelStub.calledOnce).to.be.true
+        expect(releaseConnectionStub.calledOnce).to.be.true
+        await close
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('applies the cleanup budget to reopened channel creation', async () => {
+      const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+      try {
+        sinon.stub(amqp, 'connect').resolves({} as any)
+        sinon.stub(amqp, 'createChannel' as any).returns(new Promise(() => undefined))
+        const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+        const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+        amqp.q = { queue: 'orders' }
+        amqp.config.exchange = {
+          ...amqp.config.exchange,
+          autoCreate: true,
+          name: 'orders-exchange',
+          routingKey: 'orders.v1',
+        }
+
+        await amqp.close()
+        let cleanupSettled = false
+        const cleanup = amqp.close({ removeBindings: true }).then(
+          () => {
+            cleanupSettled = true
+          },
+          () => {
+            cleanupSettled = true
+          },
+        )
+        await clock.tickAsync(5_001)
+
+        expect(cleanupSettled).to.be.true
+        expect(closeChannelStub.calledTwice).to.be.true
+        expect(releaseConnectionStub.calledTwice).to.be.true
+        await cleanup
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('applies the cleanup budget to channel close and still attempts release', async () => {
+      const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+      try {
+        amqp.channel = { unbindQueue: sinon.stub().resolves() }
+        amqp.q = { queue: 'orders' }
+        amqp.config.exchange = {
+          ...amqp.config.exchange,
+          autoCreate: true,
+          name: 'orders-exchange',
+          routingKey: 'orders.v1',
+        }
+        sinon.stub(amqp, 'closeChannel' as any).returns(new Promise(() => undefined))
+        const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+        let closeSettled = false
+        const close = amqp.close({ removeBindings: true }).then(
+          () => {
+            closeSettled = true
+          },
+          () => {
+            closeSettled = true
+          },
+        )
+        await clock.tickAsync(5_001)
+
+        expect(closeSettled).to.be.true
+        expect(releaseConnectionStub.calledOnce).to.be.true
+        await close
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('applies the cleanup budget to connection release', async () => {
+      const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+      try {
+        amqp.channel = { unbindQueue: sinon.stub().resolves() }
+        amqp.q = { queue: 'orders' }
+        amqp.config.exchange = {
+          ...amqp.config.exchange,
+          autoCreate: true,
+          name: 'orders-exchange',
+          routingKey: 'orders.v1',
+        }
+        sinon.stub(amqp, 'closeChannel' as any).resolves()
+        sinon.stub(amqp, 'releaseConnection' as any).returns(new Promise(() => undefined))
+
+        let closeSettled = false
+        const close = amqp.close({ removeBindings: true }).then(
+          () => {
+            closeSettled = true
+          },
+          () => {
+            closeSettled = true
+          },
+        )
+        await clock.tickAsync(5_001)
+
+        expect(closeSettled).to.be.true
+        await close
       } finally {
         clock.restore()
       }

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -564,6 +564,22 @@ describe('Amqp Class', () => {
     }
   })
 
+  it('removes a pending connection waiter when initialization is aborted', async () => {
+    sinon.stub(amqplib, 'connect').returns(new Promise(() => undefined))
+    const abortController = new AbortController()
+
+    const result = amqp
+      .connect({ signal: abortController.signal })
+      .then(
+        () => 'connected',
+        (error: Error) => error.message,
+      )
+    abortController.abort(new Error('initialization superseded'))
+
+    expect(await result).to.equal('initialization superseded')
+    expect((Amqp as any).pendingConnections.size).to.equal(0)
+  })
+
   it('does not share a pending connection across broker endpoint generations', async () => {
     let resolveOld: (connection: unknown) => void = () => undefined
     let resolveNew: (connection: unknown) => void = () => undefined
@@ -928,6 +944,40 @@ describe('Amqp Class', () => {
     await amqp.initialize()
     expect(createChannelStub.calledOnce).to.equal(true)
     expect(assertExchangeStub.calledOnce).to.equal(false)
+  })
+
+  it('closes a channel that resolves after initialization is aborted', async () => {
+    let resolveChannel: (channel: unknown) => void = () => undefined
+    const pendingChannel = new Promise(resolve => {
+      resolveChannel = resolve
+    })
+    const lateChannel = {
+      close: sinon.stub().resolves(),
+      on: sinon.stub(),
+      off: sinon.stub(),
+      prefetch: sinon.stub(),
+    }
+    amqp.connection = {
+      createChannel: sinon.stub().returns(pendingChannel),
+    }
+    const abortController = new AbortController()
+
+    const result = amqp
+      .initialize({ signal: abortController.signal })
+      .then(
+        () => 'initialized',
+        (error: Error) => error.message,
+      )
+    abortController.abort(new Error('initialization superseded'))
+    expect(await result).to.equal('initialization superseded')
+
+    await amqp.close()
+    resolveChannel(lateChannel)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(lateChannel.close.calledOnce).to.be.true
+    expect(lateChannel.on.called).to.be.false
   })
 
   it('initialize() skips exchange assertion when auto-create exchange is disabled', async () => {

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -396,6 +396,102 @@ describe('Amqp Class', () => {
     expect(connectionStub.close.calledOnce).to.be.true
   })
 
+  it('times out a cleanup caller without changing or removing a pending normal connection', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let resolveConnect: (connection: unknown) => void = () => undefined
+      const connectionStub = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub().resolves(),
+        connection: { stream: { destroyed: false } },
+      }
+      const connectStub = sinon.stub(amqplib, 'connect').returns(
+        new Promise(resolve => {
+          resolveConnect = resolve
+        }),
+      )
+      const normalAmqp: any = new Amqp(
+        RED,
+        { ...nodeFixture, id: 'normal' },
+        nodeConfigFixture,
+      )
+      const cleanupAmqp: any = new Amqp(
+        RED,
+        { ...nodeFixture, id: 'cleanup' },
+        nodeConfigFixture,
+      )
+
+      const normalConnection = normalAmqp.connect()
+      const cleanupConnection = cleanupAmqp.connect({ timeout: 5_000 })
+      const cleanupResult = cleanupConnection.then(
+        () => 'connected',
+        (error: Error) => error.message,
+      )
+      await clock.tickAsync(5_001)
+
+      expect(await cleanupResult).to.match(/timed out/i)
+      expect(connectStub.calledOnce).to.be.true
+      expect(connectStub.firstCall.args[1]).to.deep.equal({ heartbeat: 2 })
+      expect((Amqp as any).pendingConnections.size).to.equal(1)
+
+      resolveConnect(connectionStub)
+      expect(await normalConnection).to.equal(connectionStub)
+      expect((Amqp as any).pendingConnections.size).to.equal(0)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('does not apply a cleanup caller deadline to a normal caller joining the same pending connection', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let resolveConnect: (connection: unknown) => void = () => undefined
+      const connectionStub = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub().resolves(),
+        connection: { stream: { destroyed: false } },
+      }
+      const connectStub = sinon.stub(amqplib, 'connect').returns(
+        new Promise(resolve => {
+          resolveConnect = resolve
+        }),
+      )
+      const cleanupAmqp: any = new Amqp(
+        RED,
+        { ...nodeFixture, id: 'cleanup' },
+        nodeConfigFixture,
+      )
+      const normalAmqp: any = new Amqp(
+        RED,
+        { ...nodeFixture, id: 'normal' },
+        nodeConfigFixture,
+      )
+
+      const cleanupResult = cleanupAmqp.connect({ timeout: 5_000 }).then(
+        () => 'connected',
+        (error: Error) => error.message,
+      )
+      const normalConnection = normalAmqp.connect()
+      let normalSettled = false
+      void normalConnection.finally(() => {
+        normalSettled = true
+      })
+      await clock.tickAsync(5_001)
+
+      expect(await cleanupResult).to.match(/timed out/i)
+      expect(normalSettled).to.equal(false)
+      expect(connectStub.calledOnce).to.be.true
+      expect(connectStub.firstCall.args[1]).to.deep.equal({ heartbeat: 2 })
+
+      resolveConnect(connectionStub)
+      expect(await normalConnection).to.equal(connectionStub)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('shares one connection but uses separate channels for manual-ack input and output instances', async () => {
     const manualAckChannel = {
       prefetch: sinon.stub(),
@@ -1583,7 +1679,7 @@ describe('Amqp Class', () => {
       unbindQueueStub.onSecondCall().resolves()
       const cleanupChannel = { unbindQueue: unbindQueueStub }
       const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
-      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any).callsFake(async () => {
         amqp.channel = cleanupChannel
         return cleanupChannel as any
       })
@@ -1610,14 +1706,14 @@ describe('Amqp Class', () => {
 
       expect(unbindQueueStub.calledTwice).to.be.true
       expect(connectStub.calledOnce).to.be.true
-      expect(initializeStub.calledOnce).to.be.true
+      expect(createChannelStub.calledOnce).to.be.true
     })
 
     it('fails one terminal close after exhausting binding cleanup retries', async () => {
       const unbindQueueStub = sinon.stub().rejects(new Error('unbind failed'))
       const cleanupChannel = { unbindQueue: unbindQueueStub }
       const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
-      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any).callsFake(async () => {
         amqp.channel = cleanupChannel
         return cleanupChannel as any
       })
@@ -1652,7 +1748,7 @@ describe('Amqp Class', () => {
       )
       expect(unbindQueueStub.callCount).to.equal(3)
       expect(connectStub.callCount).to.equal(2)
-      expect(initializeStub.callCount).to.equal(2)
+      expect(createChannelStub.callCount).to.equal(2)
       expect(closeChannelStub.callCount).to.equal(3)
       expect(releaseConnectionStub.callCount).to.equal(3)
     })
@@ -1663,7 +1759,7 @@ describe('Amqp Class', () => {
         unbindQueue: unbindQueueStub,
       }
       const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
-      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any).callsFake(async () => {
         amqp.channel = cleanupChannel
         return cleanupChannel as any
       })
@@ -1689,7 +1785,7 @@ describe('Amqp Class', () => {
       await amqp.close({ removeBindings: true })
 
       expect(connectStub.calledOnce).to.be.true
-      expect(initializeStub.calledOnce).to.be.true
+      expect(createChannelStub.calledOnce).to.be.true
       expect(
         unbindQueueStub.calledOnceWith(
           'orders',
@@ -1701,13 +1797,55 @@ describe('Amqp Class', () => {
       expect(releaseConnectionStub.calledTwice).to.be.true
     })
 
+    it('does not initialize or assert obsolete topology during reopened binding cleanup', async () => {
+      const cleanupChannel = { unbindQueue: sinon.stub().resolves() }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const createChannelStub = sinon
+        .stub(amqp, 'createChannel' as any)
+        .callsFake(async () => {
+          amqp.channel = cleanupChannel
+          return cleanupChannel as any
+        })
+      const initializeStub = sinon
+        .stub(amqp, 'initialize')
+        .callsFake(async () => {
+          amqp.channel = cleanupChannel
+          return cleanupChannel as any
+        })
+      sinon.stub(amqp, 'closeChannel' as any).resolves()
+      sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'obsolete-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close()
+      await amqp.close({ removeBindings: true })
+
+      expect(connectStub.calledOnce).to.be.true
+      expect(createChannelStub.calledOnce).to.be.true
+      expect(initializeStub.called).to.be.false
+      expect(cleanupChannel.unbindQueue.calledOnce).to.be.true
+    })
+
     it('retries binding cleanup when a reopened-channel unbind fails', async () => {
       const unbindQueueStub = sinon.stub()
       unbindQueueStub.onFirstCall().rejects(new Error('unbind failed'))
       unbindQueueStub.onSecondCall().resolves()
       const cleanupChannel = { unbindQueue: unbindQueueStub }
       const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
-      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any).callsFake(async () => {
         amqp.channel = cleanupChannel
         return cleanupChannel as any
       })
@@ -1734,7 +1872,83 @@ describe('Amqp Class', () => {
 
       expect(unbindQueueStub.calledTwice).to.be.true
       expect(connectStub.calledTwice).to.be.true
-      expect(initializeStub.calledTwice).to.be.true
+      expect(createChannelStub.calledTwice).to.be.true
+    })
+
+    it('retries binding cleanup when the cleanup connection initially fails', async () => {
+      const unbindQueueStub = sinon.stub().resolves()
+      const cleanupChannel = { unbindQueue: unbindQueueStub }
+      const connectStub = sinon.stub(amqp, 'connect')
+      connectStub.onFirstCall().rejects(new Error('temporary connect failure'))
+      connectStub.onSecondCall().resolves({} as any)
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any).callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+      const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close()
+      await amqp.close({ removeBindings: true })
+
+      expect(connectStub.calledTwice).to.be.true
+      expect(createChannelStub.calledOnce).to.be.true
+      expect(unbindQueueStub.calledOnce).to.be.true
+      expect(closeChannelStub.calledTwice).to.be.true
+      expect(releaseConnectionStub.calledTwice).to.be.true
+    })
+
+    it('retries binding cleanup when cleanup channel creation initially fails', async () => {
+      const unbindQueueStub = sinon.stub().resolves()
+      const cleanupChannel = { unbindQueue: unbindQueueStub }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const createChannelStub = sinon.stub(amqp, 'createChannel' as any)
+      createChannelStub.onFirstCall().rejects(new Error('temporary channel failure'))
+      createChannelStub.onSecondCall().callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+      const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close()
+      await amqp.close({ removeBindings: true })
+
+      expect(connectStub.calledTwice).to.be.true
+      expect(createChannelStub.calledTwice).to.be.true
+      expect(unbindQueueStub.calledOnce).to.be.true
+      expect(closeChannelStub.calledThrice).to.be.true
+      expect(releaseConnectionStub.calledThrice).to.be.true
     })
 
     it('bounds a cleanup-only reconnect when the broker does not respond', async () => {
@@ -1784,12 +1998,13 @@ describe('Amqp Class', () => {
         await clock.tickAsync(4_999)
 
         expect(cleanupSettled).to.be.false
-        expect(connectStub.firstCall.args[1].timeout).to.equal(5_000)
+        expect(connectStub.firstCall.args[1]).to.deep.equal({ heartbeat: 2 })
 
-        await clock.tickAsync(2)
+        await clock.tickAsync(10_002)
         await cleanup
 
         expect(cleanupSettled).to.be.true
+        expect(connectStub.calledOnce).to.be.true
       } finally {
         clock.restore()
       }
@@ -1949,6 +2164,25 @@ describe('Amqp Class', () => {
       await (amqp as any).unbindQueues()
 
       expect(errorStub.calledOnceWithMatch('Error unbinding queue for routing key')).to.be.true
+    })
+
+    it('treats a missing queue or exchange as already clean', async () => {
+      const notFoundError = Object.assign(new Error('NOT_FOUND'), {
+        replyCode: 404,
+      })
+      const unbindQueueStub = sinon.stub().rejects(notFoundError)
+      const errorStub = sinon.stub()
+      amqp.channel = { unbindQueue: unbindQueueStub }
+      amqp.q = { queue: 'removed-queue' }
+      amqp.node = { error: errorStub }
+      amqp.config.exchange.autoCreate = true
+      amqp.setRoutingKey('orders.created,orders.updated')
+
+      const succeeded = await (amqp as any).unbindQueues(true)
+
+      expect(succeeded).to.equal(true)
+      expect(unbindQueueStub.calledOnce).to.be.true
+      expect(errorStub.called).to.be.false
     })
   })
 

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -1099,6 +1099,69 @@ describe('Amqp Class', () => {
       expect(completed).to.equal(true)
     })
 
+    it('gates later publishes through repeated channel drain cycles', async () => {
+      const { EventEmitter } = require('events')
+      const channel = new EventEmitter()
+      channel.publish = sinon.stub().returns(false)
+      amqp.channel = channel
+
+      const publishes = [
+        amqp.publish('first'),
+        amqp.publish('second'),
+        amqp.publish('third'),
+      ]
+      await new Promise(resolve => setImmediate(resolve))
+
+      expect(channel.publish.callCount).to.equal(1)
+      expect(channel.listenerCount('drain')).to.equal(1)
+      expect(channel.listenerCount('close')).to.equal(1)
+      expect(channel.listenerCount('error')).to.equal(1)
+
+      channel.emit('drain')
+      await new Promise(resolve => setImmediate(resolve))
+      expect(channel.publish.callCount).to.equal(2)
+      expect(channel.listenerCount('drain')).to.equal(1)
+
+      channel.emit('drain')
+      await new Promise(resolve => setImmediate(resolve))
+      expect(channel.publish.callCount).to.equal(3)
+      expect(channel.listenerCount('drain')).to.equal(1)
+
+      channel.emit('drain')
+      await Promise.all(publishes)
+      expect(channel.listenerCount('drain')).to.equal(0)
+      expect(channel.listenerCount('close')).to.equal(0)
+      expect(channel.listenerCount('error')).to.equal(0)
+    })
+
+    it('rejects all publishers waiting on the shared drain gate when the channel closes', async () => {
+      const { EventEmitter } = require('events')
+      const channel = new EventEmitter()
+      channel.publish = sinon.stub().returns(false)
+      amqp.channel = channel
+
+      const publishes = [
+        amqp.publish('first'),
+        amqp.publish('second'),
+        amqp.publish('third'),
+      ]
+      await new Promise(resolve => setImmediate(resolve))
+
+      expect(channel.publish.callCount).to.equal(1)
+      expect(channel.listenerCount('drain')).to.equal(1)
+      expect(channel.listenerCount('close')).to.equal(1)
+      expect(channel.listenerCount('error')).to.equal(1)
+
+      channel.emit('close')
+      const results = await Promise.allSettled(publishes)
+
+      expect(results.every(result => result.status === 'rejected')).to.equal(true)
+      expect(channel.publish.callCount).to.equal(1)
+      expect(channel.listenerCount('drain')).to.equal(0)
+      expect(channel.listenerCount('close')).to.equal(0)
+      expect(channel.listenerCount('error')).to.equal(0)
+    })
+
     it('publishes mandatory messages without publisher confirms', async () => {
       const publishStub = sinon.stub().returns(true)
       amqp.channel = {
@@ -1502,6 +1565,50 @@ describe('Amqp Class', () => {
       ).to.be.true
       expect(closeChannelStub.calledOnce).to.be.true
       expect(releaseConnectionStub.calledOnce).to.be.true
+    })
+
+    it('reopens resources to remove durable bindings after reconnect already closed them', async () => {
+      const unbindQueueStub = sinon.stub().resolves()
+      const cleanupChannel = {
+        unbindQueue: unbindQueueStub,
+      }
+      const connectStub = sinon.stub(amqp, 'connect').resolves({} as any)
+      const initializeStub = sinon.stub(amqp, 'initialize').callsFake(async () => {
+        amqp.channel = cleanupChannel
+        return cleanupChannel as any
+      })
+      const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+      const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close()
+      await amqp.close({ removeBindings: true })
+
+      expect(connectStub.calledOnce).to.be.true
+      expect(initializeStub.calledOnce).to.be.true
+      expect(
+        unbindQueueStub.calledOnceWith(
+          'orders',
+          'orders-exchange',
+          'orders.v1',
+        ),
+      ).to.be.true
+      expect(closeChannelStub.calledTwice).to.be.true
+      expect(releaseConnectionStub.calledTwice).to.be.true
     })
   })
 
@@ -2181,7 +2288,61 @@ describe('Amqp Class', () => {
         await clock.tickAsync(1001);
 
         expect(sendStub.calledOnce).to.be.true;
-        expect(sendStub.firstCall.args[0].payload.message).to.match(/Correlation ids do not match/);
+        expect(sendStub.firstCall.args[0].payload.message).to.match(/Observed 1 unmatched RPC response/);
+        expect(sendStub.firstCall.args[0].payload.message).to.not.include('wrong-id');
+        expect(deleteQueueStub.calledOnce).to.be.true;
+    });
+
+    it('bounds unmatched RPC response diagnostics across concurrent requests', async () => {
+        const sendStub = sinon.stub();
+        const deleteQueueStub = sinon.stub().resolves();
+        const assertQueueStub = sinon.stub().resolves('shared-rpc-queue');
+        let consumeCallback;
+        const consumeStub = sinon.stub().callsFake((queue, cb) => {
+            consumeCallback = cb;
+            return Promise.resolve({ consumerTag: 'shared-consumer' });
+        });
+
+        amqp.node = { ...nodeFixture, send: sendStub, error: sinon.stub() };
+        amqp.channel = {
+            assertQueue: assertQueueStub,
+            consume: consumeStub,
+            deleteQueue: deleteQueueStub,
+            publish: sinon.stub(),
+        };
+        amqp.config.outputs = 1;
+        amqp.config.rpcTimeout = 1000;
+
+        await Promise.all([
+            amqp.publish('request-one', {
+                correlationId: 'correlation-one',
+                replyTo: 'shared-rpc-queue',
+            }),
+            amqp.publish('request-two', {
+                correlationId: 'correlation-two',
+                replyTo: 'shared-rpc-queue',
+            }),
+        ]);
+
+        const peerControlledPrefix = `peer-controlled-${'x'.repeat(1024)}`;
+        for (let index = 0; index < 150; index += 1) {
+            consumeCallback({
+                properties: {
+                    correlationId: `${peerControlledPrefix}-${index}`,
+                },
+                content: Buffer.from('{"late":true}'),
+            });
+        }
+
+        await clock.tickAsync(1001);
+
+        expect(sendStub.callCount).to.equal(2);
+        for (const call of sendStub.getCalls()) {
+            const message = call.args[0].payload.message;
+            expect(message).to.match(/Observed 100\+ unmatched RPC responses/);
+            expect(message).to.not.include('peer-controlled');
+            expect(message.length).to.be.lessThan(250);
+        }
         expect(deleteQueueStub.calledOnce).to.be.true;
     });
 

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -993,6 +993,23 @@ describe('Amqp Class', () => {
       expect(publishStub.calledOnce).to.equal(true)
     })
 
+    it('uses a per-call routing key without mutating configured routing', async () => {
+      const publishStub = sinon.stub().returns(true)
+      amqp.channel = { publish: publishStub }
+      amqp.config.exchange.routingKey = 'configured.route'
+
+      await Promise.all([
+        amqp.publish('first', undefined, 'route.first'),
+        amqp.publish('second', undefined, 'route.second'),
+      ])
+
+      expect(publishStub.getCalls().map(call => call.args[1])).to.deep.equal([
+        'route.first',
+        'route.second',
+      ])
+      expect(amqp.config.exchange.routingKey).to.equal('configured.route')
+    })
+
     it('publishes a message (direct w/RPC)', async () => {
       // @ts-ignore
       amqp = new Amqp(RED, nodeFixture, {
@@ -1030,19 +1047,37 @@ describe('Amqp Class', () => {
       // expect(publishStub.calledOnce).to.equal(true)
     })
 
-    it('waits for confirms when enabled', async () => {
-      const publishStub = sinon.stub()
-      const waitForConfirmsStub = sinon.stub().resolves()
+    it('waits for the individual publish confirmation when enabled', async () => {
+      let confirmPublish: (error: Error | null) => void = () => undefined
+      const publishStub = sinon.stub().callsFake(
+        (
+          exchange: string,
+          routingKey: string,
+          content: Buffer,
+          options: unknown,
+          confirm: (error: Error | null) => void,
+        ) => {
+          confirmPublish = confirm
+          return true
+        },
+      )
       amqp.channel = {
         publish: publishStub,
-        waitForConfirms: waitForConfirmsStub,
       }
       amqp.config.waitForConfirms = true
 
-      await amqp.publish('a message')
+      let completed = false
+      const publish = amqp.publish('a message').then(() => {
+        completed = true
+      })
+      await Promise.resolve()
+
+      expect(completed).to.equal(false)
+      confirmPublish(null)
+      await publish
 
       expect(publishStub.calledOnce).to.equal(true)
-      expect(waitForConfirmsStub.calledOnce).to.equal(true)
+      expect(publishStub.firstCall.args[4]).to.be.a('function')
     })
 
     it('waits for channel drain when publish applies backpressure', async () => {
@@ -1064,12 +1099,22 @@ describe('Amqp Class', () => {
       expect(completed).to.equal(true)
     })
 
-    it('rejects a confirmed publish when the broker returns a mandatory message', async () => {
+    it('publishes mandatory messages without publisher confirms', async () => {
+      const publishStub = sinon.stub().returns(true)
+      amqp.channel = {
+        publish: publishStub,
+      }
+      amqp.config.waitForConfirms = false
+
+      await amqp.publish('a message', { mandatory: true })
+
+      expect(publishStub.calledOnce).to.equal(true)
+      expect(publishStub.firstCall.args[3].mandatory).to.equal(true)
+    })
+
+    it('reports unconfirmed mandatory returns through the channel warning', async () => {
       const events: Record<string, (message?: unknown) => void> = {}
-      let releaseConfirm: () => void = () => undefined
-      const confirmPending = new Promise<void>(resolve => {
-        releaseConfirm = resolve
-      })
+      const warnStub = sinon.stub()
       const channel = {
         on: sinon.stub().callsFake(
           (event: string, callback: (message?: unknown) => void) => {
@@ -1077,8 +1122,67 @@ describe('Amqp Class', () => {
           },
         ),
         prefetch: sinon.stub().resolves(),
-        publish: sinon.stub().returns(true),
-        waitForConfirms: sinon.stub().returns(confirmPending),
+        publish: sinon.stub().callsFake(
+          (
+            exchange: string,
+            routingKey: string,
+            content: Buffer,
+            options: unknown,
+          ) => {
+            events.return({
+              fields: {
+                replyCode: 312,
+                replyText: 'NO_ROUTE',
+                exchange,
+                routingKey,
+              },
+              properties: options,
+              content,
+            })
+            return true
+          },
+        ),
+      }
+      amqp.node = {
+        ...nodeFixture,
+        warn: warnStub,
+      }
+      amqp.connection = {
+        createChannel: sinon.stub().resolves(channel),
+      }
+      amqp.config.waitForConfirms = false
+      await amqp.initialize()
+
+      await amqp.publish('a message', { mandatory: true })
+
+      expect(channel.publish.calledOnce).to.equal(true)
+      expect(warnStub.calledOnceWithMatch('AMQP Message returned')).to.equal(
+        true,
+      )
+    })
+
+    it('rejects a confirmed publish when the broker returns a mandatory message', async () => {
+      const events: Record<string, (message?: unknown) => void> = {}
+      let confirmPublish: (error: Error | null) => void = () => undefined
+      const channel = {
+        on: sinon.stub().callsFake(
+          (event: string, callback: (message?: unknown) => void) => {
+            events[event] = callback
+          },
+        ),
+        prefetch: sinon.stub().resolves(),
+        publish: sinon.stub().callsFake(
+          (
+            exchange: string,
+            routingKey: string,
+            content: Buffer,
+            options: unknown,
+            confirm: (error: Error | null) => void,
+          ) => {
+            confirmPublish = confirm
+            return true
+          },
+        ),
       }
       amqp.connection = {
         createConfirmChannel: sinon.stub().resolves(channel),
@@ -1108,7 +1212,7 @@ describe('Amqp Class', () => {
         properties: publishedOptions,
         content: Buffer.from('a message'),
       })
-      releaseConfirm()
+      confirmPublish(null)
 
       const publishError = await publishResult
       expect(publishError).to.be.instanceOf(Error)
@@ -1129,6 +1233,7 @@ describe('Amqp Class', () => {
             routingKey: string,
             content: Buffer,
             options: unknown,
+            confirm: (error: Error | null) => void,
           ) => {
             if (routingKey === 'route.missing') {
               events.return({
@@ -1142,10 +1247,10 @@ describe('Amqp Class', () => {
                 content,
               })
             }
+            queueMicrotask(() => confirm(null))
             return true
           },
         ),
-        waitForConfirms: sinon.stub().resolves(),
       }
       amqp.connection = {
         createConfirmChannel: sinon.stub().resolves(channel),
@@ -1164,6 +1269,45 @@ describe('Amqp Class', () => {
       expect(publishError).to.be.instanceOf(Error)
       expect(publishError.successfulRoutingKeys).to.deep.equal(['route.ok'])
       expect(publishError.failedRoutingKeys).to.deep.equal(['route.missing'])
+    })
+
+    it('attributes publisher confirms to their individual routing keys', async () => {
+      const channel = {
+        publish: sinon.stub().callsFake(
+          (
+            exchange: string,
+            routingKey: string,
+            content: Buffer,
+            options: unknown,
+            confirm?: (error: Error | null) => void,
+          ) => {
+            queueMicrotask(() => {
+              confirm?.(
+                routingKey === 'route.failed'
+                  ? new Error('broker nacked route.failed')
+                  : null,
+              )
+            })
+            return true
+          },
+        ),
+        waitForConfirms: sinon
+          .stub()
+          .rejects(new Error('an earlier publish was nacked')),
+      }
+      amqp.channel = channel
+      amqp.config.exchange.routingKey = 'route.failed,route.ok'
+      amqp.config.waitForConfirms = true
+
+      const publishError = await amqp.publish('a message').then(
+        () => undefined,
+        (error: unknown) => error,
+      )
+
+      expect(publishError).to.be.instanceOf(Error)
+      expect(publishError.successfulRoutingKeys).to.deep.equal(['route.ok'])
+      expect(publishError.failedRoutingKeys).to.deep.equal(['route.failed'])
+      expect(channel.waitForConfirms.called).to.equal(false)
     })
 
     it('tries to publish an invalid message', async () => {
@@ -1322,6 +1466,40 @@ describe('Amqp Class', () => {
       await amqp.close()
 
       expect(unbindQueueStub.called).to.be.false
+      expect(closeChannelStub.calledOnce).to.be.true
+      expect(releaseConnectionStub.calledOnce).to.be.true
+    })
+
+    it('unbinds the configured route from a durable named queue on terminal close', async () => {
+      const unbindQueueStub = sinon.stub().resolves()
+      const closeChannelStub = sinon.stub(amqp, 'closeChannel' as any).resolves()
+      const releaseConnectionStub = sinon.stub(amqp, 'releaseConnection' as any).resolves()
+
+      amqp.channel = { unbindQueue: unbindQueueStub }
+      amqp.q = { queue: 'orders' }
+      amqp.config.exchange = {
+        ...amqp.config.exchange,
+        autoCreate: true,
+        name: 'orders-exchange',
+        routingKey: 'orders.v1',
+      }
+      amqp.config.queue = {
+        ...amqp.config.queue,
+        name: 'orders',
+        durable: true,
+        exclusive: false,
+        autoDelete: false,
+      }
+
+      await amqp.close({ removeBindings: true })
+
+      expect(
+        unbindQueueStub.calledOnceWith(
+          'orders',
+          'orders-exchange',
+          'orders.v1',
+        ),
+      ).to.be.true
       expect(closeChannelStub.calledOnce).to.be.true
       expect(releaseConnectionStub.calledOnce).to.be.true
     })
@@ -1539,6 +1717,65 @@ describe('Amqp Class', () => {
     expect(amqp.channel).to.eq(result)
     expect(result.prefetch.calledOnce).to.equal(true)
   })
+
+  for (const [channelType, waitForConfirms] of [
+    ['regular', false],
+    ['confirm', true],
+  ] as const) {
+    it(`closes a stale ${channelType} channel that finishes creation after reconnect`, async () => {
+      let resolveChannel: (channel: unknown) => void = () => undefined
+      const pendingChannel = new Promise(resolve => {
+        resolveChannel = resolve
+      })
+      const lateChannel = {
+        close: sinon.stub().resolves(),
+        off: sinon.stub(),
+        on: sinon.stub(),
+        prefetch: sinon.stub(),
+      }
+      const sharedConnection = {
+        close: sinon.stub().resolves(),
+        createChannel: sinon.stub(),
+        createConfirmChannel: sinon.stub(),
+        off: sinon.stub(),
+        on: sinon.stub(),
+      }
+      const createChannelStub = waitForConfirms
+        ? sharedConnection.createConfirmChannel
+        : sharedConnection.createChannel
+      createChannelStub.returns(pendingChannel)
+
+      amqp.broker = brokerConfigFixture
+      amqp.config.waitForConfirms = waitForConfirms
+      amqp.connection = sharedConnection
+      amqp.channel = undefined
+      const poolKey = `${amqp.config.broker}:${brokerConfigFixture.vhost}`
+      ;(Amqp as any).connectionPool.set(poolKey, {
+        connection: sharedConnection,
+        count: 2,
+      })
+
+      const initialization = amqp.initialize()
+      expect(createChannelStub.calledOnce).to.equal(true)
+
+      await amqp.close()
+      await amqp.connect()
+      resolveChannel(lateChannel)
+      const initializationResult = await initialization.then(
+        () => 'fulfilled',
+        () => 'rejected',
+      )
+
+      // This mirrors stale-initialization cleanup after reconnect started.
+      await amqp.close()
+
+      expect(initializationResult).to.equal('rejected')
+      expect(lateChannel.close.calledOnce).to.equal(true)
+      expect(lateChannel.prefetch.called).to.equal(false)
+      expect(lateChannel.on.called).to.equal(false)
+      expect(sharedConnection.close.called).to.equal(false)
+    })
+  }
 
   it('createChannel() logs events', async () => {
     const events: { [key: string]: Function } = {}

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -2933,6 +2933,27 @@ describe('Amqp Class', () => {
       expect((amqp as any).vhostOverride).to.equal('vh2')
     })
 
+    it('does not log an expected aborted vhost switch as an AMQP failure', async () => {
+      amqp.broker = { ...brokerConfigFixture, vhost: 'vh1' }
+      sinon.stub(amqp, 'close').resolves()
+      sinon.stub(amqp, 'connect').callsFake(async (options: { signal?: AbortSignal }) => {
+        throw options.signal?.reason ?? new Error('switch failed')
+      })
+      const errorStub = sinon.stub(amqp.node, 'error')
+      const controller = new AbortController()
+      controller.abort(new Error('shutdown'))
+
+      let switchError: Error | undefined
+      try {
+        await amqp.setVhost('vh2', { signal: controller.signal })
+      } catch (error) {
+        switchError = error as Error
+      }
+
+      expect(switchError?.message).to.equal('shutdown')
+      expect(errorStub.called).to.equal(false)
+    })
+
     it('does nothing when vhost is unchanged', async () => {
       amqp.broker = { ...brokerConfigFixture, vhost: 'vh1' }
       ;(amqp as any).closed = false

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -2935,6 +2935,10 @@ describe('Amqp Class', () => {
 
     it('does nothing when vhost is unchanged', async () => {
       amqp.broker = { ...brokerConfigFixture, vhost: 'vh1' }
+      ;(amqp as any).closed = false
+      ;(amqp as any).connection = {}
+      ;(amqp as any).channel = {}
+      ;(amqp as any).initializedVhost = 'vh1'
       const closeStub = sinon.stub(amqp, 'close').resolves()
       const connectStub = sinon.stub(amqp, 'connect').resolves()
       const initStub = sinon.stub(amqp, 'initialize').resolves()
@@ -2945,6 +2949,51 @@ describe('Amqp Class', () => {
       expect(connectStub.called).to.equal(false)
       expect(initStub.called).to.equal(false)
       expect((amqp as any).vhostOverride).to.be.undefined
+    })
+
+    it('retries the same vhost after a failed switch and cleans partial resources', async () => {
+      amqp.broker = { ...brokerConfigFixture, vhost: 'vh1' }
+      const closeStub = sinon.stub(amqp, 'close').callsFake(async () => {
+        ;(amqp as any).closed = true
+        ;(amqp as any).connection = undefined
+        ;(amqp as any).channel = undefined
+        ;(amqp as any).initializedVhost = undefined
+      })
+      const connectStub = sinon.stub(amqp, 'connect')
+      connectStub.onFirstCall().callsFake(async () => {
+        ;(amqp as any).closed = false
+        ;(amqp as any).connection = {}
+      })
+      connectStub.onSecondCall().callsFake(async () => {
+        ;(amqp as any).closed = false
+        ;(amqp as any).connection = {}
+      })
+      const initializeStub = sinon.stub(amqp, 'initialize')
+      initializeStub.onFirstCall().callsFake(async () => {
+        ;(amqp as any).channel = {}
+        throw new Error('transient switch failure')
+      })
+      initializeStub.onSecondCall().callsFake(async () => {
+        ;(amqp as any).channel = {}
+        ;(amqp as any).initializedVhost = 'vh2'
+        return (amqp as any).channel
+      })
+
+      let switchError: Error | undefined
+      try {
+        await amqp.setVhost('vh2')
+      } catch (error) {
+        switchError = error as Error
+      }
+      expect(switchError?.message).to.equal('transient switch failure')
+      expect(amqp.isInitializedForVhost('vh2')).to.equal(false)
+
+      await amqp.setVhost('vh2')
+
+      expect(connectStub.calledTwice).to.equal(true)
+      expect(initializeStub.calledTwice).to.equal(true)
+      expect(closeStub.callCount).to.equal(3)
+      expect(amqp.isInitializedForVhost('vh2')).to.equal(true)
     })
 
     it('does not mutate shared broker config', async () => {

--- a/test/amqp-lifecycle-coordinator.spec.ts
+++ b/test/amqp-lifecycle-coordinator.spec.ts
@@ -1,0 +1,107 @@
+export {}
+const { expect } = require('chai')
+const sinon = require('sinon')
+const AmqpLifecycleCoordinator =
+  require('../src/amqp-lifecycle-coordinator').default
+
+describe('AmqpLifecycleCoordinator', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  const createNode = () => ({
+    log: sinon.stub(),
+  })
+
+  it('aborts a stalled replacement operation during shutdown', async () => {
+    const close = sinon.stub().resolves()
+    const coordinator = new AmqpLifecycleCoordinator({
+      node: createNode(),
+      initialize: sinon.stub().resolves(),
+      close,
+      removeEventListeners: sinon.stub(),
+      clearResources: sinon.stub(),
+      onInitializationError: sinon.stub().resolves(),
+    })
+    await coordinator.start()
+
+    let replacementSignal: AbortSignal | undefined
+    let notifyStarted: () => void = () => undefined
+    const started = new Promise<void>(resolve => {
+      notifyStarted = resolve
+    })
+    const replacement = coordinator.replace(
+      new Error('replace current lifecycle'),
+      async ({ signal }: { signal: AbortSignal }) => {
+        replacementSignal = signal
+        notifyStarted()
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(signal.reason),
+            { once: true },
+          )
+        })
+      },
+    )
+    await started
+
+    coordinator.shutdown(new Error('node shutdown'))
+
+    let replacementError: Error | undefined
+    await replacement.catch((error: Error) => {
+      replacementError = error
+    })
+    expect(replacementSignal?.aborted).to.equal(true)
+    expect(replacementError?.message).to.equal('node shutdown')
+  })
+
+  it('does not start scheduled reconnect initialization after shutdown', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const initialize = sinon.stub().resolves()
+      const coordinator = new AmqpLifecycleCoordinator({
+        node: createNode(),
+        initialize,
+        close: sinon.stub().resolves(),
+        removeEventListeners: sinon.stub(),
+        clearResources: sinon.stub(),
+        onInitializationError: sinon.stub().resolves(),
+      })
+      await coordinator.start()
+      await coordinator.reconnect()
+
+      coordinator.shutdown(new Error('node shutdown'))
+      await clock.tickAsync(2001)
+
+      expect(initialize.calledOnce).to.equal(true)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('coalesces reconnect requests through one shared backoff timer', async () => {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const initialize = sinon.stub().resolves()
+      const close = sinon.stub().resolves()
+      const coordinator = new AmqpLifecycleCoordinator({
+        node: createNode(),
+        initialize,
+        close,
+        removeEventListeners: sinon.stub(),
+        clearResources: sinon.stub(),
+        onInitializationError: sinon.stub().resolves(),
+      })
+      await coordinator.start()
+
+      await Promise.all([coordinator.reconnect(), coordinator.reconnect()])
+      await clock.tickAsync(2001)
+
+      expect(close.calledOnce).to.equal(true)
+      expect(initialize.calledTwice).to.equal(true)
+    } finally {
+      clock.restore()
+    }
+  })
+})

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -599,7 +599,7 @@ describe('amqp-in-manual-ack Node', () => {
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
     sinon.stub(Amqp.prototype, 'consume').resolves()
-    sinon.stub(Amqp.prototype, 'close').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
     const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
 
     await helper.load(
@@ -610,6 +610,7 @@ describe('amqp-in-manual-ack Node', () => {
     const node = helper.getNode('n1')
     await node.close(true)
 
+    expect(closeStub.calledOnceWith({ removeBindings: true })).to.be.true
     expect(removeBrokerNodeStateStub.calledOnce).to.be.true
   })
 

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -936,6 +936,88 @@ describe('amqp-in-manual-ack Node', () => {
     }
   })
 
+  it('manual reconnect aborts a stalled startup connection', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      let firstAborted = false
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              firstAborted = true
+              reject(new Error('startup connection cancelled'))
+            }, { once: true })
+          }) as any,
+      )
+      connectStub.onSecondCall().resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      expect(firstAborted).to.be.true
+      await clock.tickAsync(2_001)
+
+      expect(connectStub.calledTwice).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('manual reconnect aborts stalled startup channel creation', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      let notifyInitializationStarted: () => void = () => undefined
+      const initializationStarted = new Promise<void>(resolve => {
+        notifyInitializationStarted = resolve
+      })
+      let firstAborted = false
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize')
+      initializeStub.onFirstCall().callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            notifyInitializationStarted()
+            options?.signal?.addEventListener('abort', () => {
+              firstAborted = true
+              reject(new Error('startup channel cancelled'))
+            }, { once: true })
+          }) as any,
+      )
+      initializeStub.onSecondCall().resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+      await initializationStarted
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      expect(firstAborted).to.be.true
+      await clock.tickAsync(2_001)
+
+      expect(initializeStub.calledTwice).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('coalesces repeated reconnect control messages into a single reconnect cycle', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub() } as any)

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -614,6 +614,30 @@ describe('amqp-in-manual-ack Node', () => {
     expect(removeBrokerNodeStateStub.calledOnce).to.be.true
   })
 
+  it('removes durable bindings when the node configuration changes', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+    helper._events.emit('flows:stopping', {
+      type: 'nodes',
+      diff: { changed: ['n1'], removed: [] },
+    })
+
+    const node = helper.getNode('n1')
+    await node.close(false)
+
+    expect(closeStub.calledOnceWith({ removeBindings: true })).to.be.true
+  })
+
   it('reconnects on channel close even when reconnectOnError is false', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
@@ -830,6 +854,51 @@ describe('amqp-in-manual-ack Node', () => {
     await clock.tickAsync(2001)
     expect(connectStub.callCount).to.equal(2)
     clock.restore()
+  })
+
+  it('does not queue duplicate initialization after the reconnect timer fires', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      const consumeStub = sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon
+        .stub(Amqp.prototype, 'markConnected')
+        .onFirstCall()
+        .throws(new Error('hold initial initialization open'))
+
+      let releaseInitialCleanup: () => void = () => undefined
+      const initialCleanup = new Promise<void>(resolve => {
+        releaseInitialCleanup = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(initialCleanup)
+      closeStub.resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      await onConnClose()
+      await clock.tickAsync(2001)
+
+      await onConnClose()
+      await clock.tickAsync(4001)
+
+      releaseInitialCleanup()
+      await clock.tickAsync(0)
+
+      expect(connectStub.callCount).to.equal(2)
+      expect(initializeStub.callCount).to.equal(2)
+      expect(consumeStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
   })
 
   it('coalesces repeated reconnect control messages into a single reconnect cycle', async function () {

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -901,6 +901,41 @@ describe('amqp-in-manual-ack Node', () => {
     }
   })
 
+  it('does not start a queued reconnect initialization after shutdown', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let releaseInitialConnect: (connection: unknown) => void = () => undefined
+      const initialConnect = new Promise(resolve => {
+        releaseInitialConnect = resolve
+      })
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().returns(initialConnect as any)
+      connectStub.onSecondCall().resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      await clock.tickAsync(2_001)
+      await n1.close()
+
+      releaseInitialConnect(connectionMock)
+      await clock.tickAsync(0)
+
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('coalesces repeated reconnect control messages into a single reconnect cycle', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     sinon.stub(Amqp.prototype, 'connect').resolves({ on: sinon.stub(), off: sinon.stub() } as any)

--- a/test/nodes/amqp-in-manual-ack.spec.ts
+++ b/test/nodes/amqp-in-manual-ack.spec.ts
@@ -74,11 +74,11 @@ describe('amqp-in-manual-ack Node', () => {
     let ackStub, ackAllStub, nackStub, nackAllStub, rejectStub;
 
     beforeEach(() => {
-      ackStub = sinon.stub(Amqp.prototype, 'ack');
-      ackAllStub = sinon.stub(Amqp.prototype, 'ackAll');
-      nackStub = sinon.stub(Amqp.prototype, 'nack');
-      nackAllStub = sinon.stub(Amqp.prototype, 'nackAll');
-      rejectStub = sinon.stub(Amqp.prototype, 'reject');
+      ackStub = sinon.stub(Amqp.prototype, 'ack').returns(true);
+      ackAllStub = sinon.stub(Amqp.prototype, 'ackAll').returns(true);
+      nackStub = sinon.stub(Amqp.prototype, 'nack').returns(true);
+      nackAllStub = sinon.stub(Amqp.prototype, 'nackAll').returns(true);
+      rejectStub = sinon.stub(Amqp.prototype, 'reject').returns(true);
     });
 
     it('should ack a message by default', done => {
@@ -134,6 +134,41 @@ describe('amqp-in-manual-ack Node', () => {
         done();
       });
     });
+
+    it('calls done with an error when acknowledgement fails', async function () {
+      ackStub.returns(false)
+      sinon
+        .stub(Amqp.prototype, 'connect')
+        .resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon
+        .stub(Amqp.prototype, 'initialize')
+        .resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+
+      await helper.load(
+        [amqpInManualAck, amqpBroker],
+        amqpInManualAckFlowFixture,
+        credentialsFixture,
+      )
+
+      const n1 = helper.getNode('n1')
+      const callErrors: unknown[] = []
+      n1.on('call:error', call => {
+        callErrors.push(call.args[0])
+      })
+
+      n1.receive({
+        payload: 'test',
+        manualAck: { ackMode: ManualAckType.Ack },
+      })
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(ackStub.calledOnce).to.be.true
+      const doneError = callErrors.find(
+        argument => argument instanceof Error,
+      ) as Error | undefined
+      expect(doneError).to.not.equal(undefined)
+    })
   });
 
   it('tries to connect but the broker is down', function (done) {
@@ -416,6 +451,39 @@ describe('amqp-in-manual-ack Node', () => {
       expect(nackStub.notCalled).to.be.true
       done()
     })
+  })
+
+  it('acknowledges an AMQP delivery whose business payload contains reconnectCall', async function () {
+    const ackStub = sinon.stub(Amqp.prototype, 'ack').returns(true)
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpInManualAck, amqpBroker],
+      amqpInManualAckFlowFixture,
+      credentialsFixture,
+    )
+
+    const node = helper.getNode('n1')
+    node.receive({
+      payload: { reconnectCall: true, orderId: 'order-42' },
+      fields: { deliveryTag: 42 },
+      properties: {},
+      content: Buffer.from('{"reconnectCall":true,"orderId":"order-42"}'),
+      manualAck: { ackMode: ManualAckType.Ack },
+    })
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(ackStub.calledOnce).to.be.true
+    expect(closeStub.called).to.be.false
   })
 
   it('removes channel close listener on node close', async function () {
@@ -1024,6 +1092,49 @@ describe('amqp-in-manual-ack Node', () => {
       expect(connectStub.callCount).to.equal(2)
 
       await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('keeps retrying after broker-close recovery fails with reconnectOnError disabled', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const initialConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const recoveredConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().resolves(initialConnection as any)
+      connectStub
+        .onSecondCall()
+        .rejects(new Error('broker is still restarting'))
+      connectStub.onThirdCall().resolves(recoveredConnection as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInManualAckFlowFixture))
+      flow[0].reconnectOnError = false
+
+      await helper.load([amqpInManualAck, amqpBroker], flow, credentialsFixture)
+      const onConnectionClose = initialConnection.on
+        .withArgs('close')
+        .getCall(0).args[1]
+
+      await onConnectionClose()
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(4001)
       expect(connectStub.callCount).to.equal(3)
     } finally {
       clock.restore()

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -797,6 +797,41 @@ describe('amqp-in Node', () => {
     }
   })
 
+  it('does not start a queued reconnect initialization after shutdown', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let releaseInitialConnect: (connection: unknown) => void = () => undefined
+      const initialConnect = new Promise(resolve => {
+        releaseInitialConnect = resolve
+      })
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().returns(initialConnect as any)
+      connectStub.onSecondCall().resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves({ on: sinon.stub(), off: sinon.stub() } as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      await clock.tickAsync(2_001)
+      await n1.close()
+
+      releaseInitialConnect(connectionMock)
+      await clock.tickAsync(0)
+
+      expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('handles channel close', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() };
     const channelMock = { on: sinon.stub(), off: sinon.stub() };

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -650,7 +650,7 @@ describe('amqp-in Node', () => {
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
     sinon.stub(Amqp.prototype, 'consume').resolves()
-    sinon.stub(Amqp.prototype, 'close').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
     const removeBrokerNodeStateStub = sinon.stub(Amqp.prototype, 'removeBrokerNodeState')
 
     await helper.load(
@@ -661,6 +661,7 @@ describe('amqp-in Node', () => {
     const amqpInNode = helper.getNode('n1')
     await amqpInNode.close(true)
 
+    expect(closeStub.calledOnceWith({ removeBindings: true })).to.be.true
     expect(removeBrokerNodeStateStub.calledOnce).to.be.true
   })
 

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -665,6 +665,30 @@ describe('amqp-in Node', () => {
     expect(removeBrokerNodeStateStub.calledOnce).to.be.true
   })
 
+  it('removes durable bindings when the node configuration changes', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub(), consume: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'consume').resolves()
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+
+    await helper.load(
+      [amqpIn, amqpBroker],
+      amqpInFlowFixture,
+      credentialsFixture,
+    )
+    helper._events.emit('flows:stopping', {
+      type: 'nodes',
+      diff: { changed: ['n1'], removed: [] },
+    })
+
+    const node = helper.getNode('n1')
+    await node.close(false)
+
+    expect(closeStub.calledOnceWith({ removeBindings: true })).to.be.true
+  })
+
   it('does not schedule reconnect when node closes while reconnect is closing resources', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {
@@ -726,6 +750,51 @@ describe('amqp-in Node', () => {
     await clock.tickAsync(2001)
     expect(connectStub.callCount).to.equal(2)
     clock.restore()
+  })
+
+  it('does not queue duplicate initialization after the reconnect timer fires', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      const consumeStub = sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon
+        .stub(Amqp.prototype, 'markConnected')
+        .onFirstCall()
+        .throws(new Error('hold initial initialization open'))
+
+      let releaseInitialCleanup: () => void = () => undefined
+      const initialCleanup = new Promise<void>(resolve => {
+        releaseInitialCleanup = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(initialCleanup)
+      closeStub.resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      await onConnClose()
+      await clock.tickAsync(2001)
+
+      await onConnClose()
+      await clock.tickAsync(4001)
+
+      releaseInitialCleanup()
+      await clock.tickAsync(0)
+
+      expect(connectStub.callCount).to.equal(2)
+      expect(initializeStub.callCount).to.equal(2)
+      expect(consumeStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
   })
 
   it('handles channel close', async function () {

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -489,6 +489,54 @@ describe('amqp-in Node', () => {
     expect(callErrors.some(err => String(err).includes('ERR_INVALID_ARG_TYPE'))).to.be.false
   })
 
+  it('does not create duplicate consumers when reconnect is requested during initialization', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      let resolveInitialConnect: (connection: unknown) => void = () => undefined
+      const initialConnectPending = new Promise(resolve => {
+        resolveInitialConnect = resolve
+      })
+      const initialConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const retryConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const channelMock = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+      }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().returns(initialConnectPending as any)
+      connectStub.onSecondCall().resolves(retryConnection as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      const consumeStub = sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+
+      const node = helper.getNode('n1')
+      node.receive({ payload: { reconnectCall: true } })
+      await clock.tickAsync(0)
+
+      resolveInitialConnect(initialConnection)
+      await clock.tickAsync(0)
+      await clock.tickAsync(2001)
+
+      expect(consumeStub.callCount).to.equal(1)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('should handle channel errors', function (done) {
     const flow = [
       { id: 'n1', type: 'amqp-in', name: 'test name', broker: 'b1' },
@@ -914,6 +962,49 @@ describe('amqp-in Node', () => {
       expect(connectStub.callCount).to.equal(2)
 
       await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('keeps retrying after broker-close recovery fails with reconnectOnError disabled', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const initialConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const recoveredConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().resolves(initialConnection as any)
+      connectStub
+        .onSecondCall()
+        .rejects(new Error('broker is still restarting'))
+      connectStub.onThirdCall().resolves(recoveredConnection as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpInFlowFixture))
+      flow[0].reconnectOnError = false
+
+      await helper.load([amqpIn, amqpBroker], flow, credentialsFixture)
+      const onConnectionClose = initialConnection.on
+        .withArgs('close')
+        .getCall(0).args[1]
+
+      await onConnectionClose()
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(4001)
       expect(connectStub.callCount).to.equal(3)
     } finally {
       clock.restore()

--- a/test/nodes/amqp-in.spec.ts
+++ b/test/nodes/amqp-in.spec.ts
@@ -832,6 +832,88 @@ describe('amqp-in Node', () => {
     }
   })
 
+  it('manual reconnect aborts a stalled startup connection', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      let firstAborted = false
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener('abort', () => {
+              firstAborted = true
+              reject(new Error('startup connection cancelled'))
+            }, { once: true })
+          }) as any,
+      )
+      connectStub.onSecondCall().resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      expect(firstAborted).to.be.true
+      await clock.tickAsync(2_001)
+
+      expect(connectStub.calledTwice).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('manual reconnect aborts stalled startup channel creation', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      let notifyInitializationStarted: () => void = () => undefined
+      const initializationStarted = new Promise<void>(resolve => {
+        notifyInitializationStarted = resolve
+      })
+      let firstAborted = false
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize')
+      initializeStub.onFirstCall().callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            notifyInitializationStarted()
+            options?.signal?.addEventListener('abort', () => {
+              firstAborted = true
+              reject(new Error('startup channel cancelled'))
+            }, { once: true })
+          }) as any,
+      )
+      initializeStub.onSecondCall().resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'consume').resolves()
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      await helper.load(
+        [amqpIn, amqpBroker],
+        amqpInFlowFixture,
+        credentialsFixture,
+      )
+      await initializationStarted
+      const n1 = helper.getNode('n1')
+
+      await n1.receive({ payload: { reconnectCall: true } })
+      expect(firstAborted).to.be.true
+      await clock.tickAsync(2_001)
+
+      expect(initializeStub.calledTwice).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('handles channel close', async function () {
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() };
     const channelMock = { on: sinon.stub(), off: sinon.stub() };

--- a/test/nodes/amqp-mixed-flow.spec.ts
+++ b/test/nodes/amqp-mixed-flow.spec.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+export {}
+const { expect } = require('chai')
+const sinon = require('sinon')
+const Amqp = require('../../src/Amqp').default
+const { credentialsFixture } = require('../doubles')
+const helper = require('node-red-node-test-helper')
+const amqpInManualAck = require('../../src/nodes/amqp-in-manual-ack')
+const amqpOut = require('../../src/nodes/amqp-out')
+const amqpBroker = require('../../src/nodes/amqp-broker')
+
+helper.init(require.resolve('node-red'))
+
+describe('mixed AMQP flow', () => {
+  beforeEach(function (done) {
+    helper.startServer(done)
+  })
+
+  afterEach(function (done) {
+    helper.unload()
+    helper.stopServer(done)
+    sinon.restore()
+  })
+
+  it('reconnects both manual-ack input and output nodes after their shared connection closes', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const sharedConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const channel = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+      }
+      const connectStub = sinon
+        .stub(Amqp.prototype, 'connect')
+        .resolves(sharedConnection as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channel as any)
+      const consumeStub = sinon.stub(Amqp.prototype, 'consume').resolves()
+      const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+      const flow = [
+        {
+          id: 'manual-in',
+          type: 'amqp-in-manual-ack',
+          broker: 'broker',
+          queueName: 'manual-ack-queue',
+          reconnectOnError: false,
+          wires: [],
+        },
+        {
+          id: 'out',
+          type: 'amqp-out',
+          broker: 'broker',
+          exchangeName: 'events',
+          exchangeType: 'topic',
+          exchangeRoutingKey: 'events.test',
+          exchangeRoutingKeyType: 'str',
+          amqpProperties: '{}',
+          reconnectOnError: false,
+          wires: [],
+        },
+        {
+          id: 'broker',
+          type: 'amqp-broker',
+          host: 'localhost',
+          port: '5672',
+        },
+      ]
+
+      await helper.load(
+        [amqpInManualAck, amqpOut, amqpBroker],
+        flow,
+        credentialsFixture,
+      )
+
+      const closeHandlers = sharedConnection.on
+        .withArgs('close')
+        .getCalls()
+        .map(call => call.args[1])
+      expect(connectStub.callCount).to.equal(2)
+      expect(closeHandlers).to.have.length(2)
+      expect(consumeStub.calledOnce).to.be.true
+
+      await Promise.all(closeHandlers.map(handler => handler()))
+      expect(closeStub.calledTwice).to.be.true
+
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(4)
+      expect(consumeStub.calledTwice).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+})

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -1283,6 +1283,49 @@ describe('amqp-out Node', () => {
     clock.restore()
   })
 
+  it('does not queue duplicate initialization after the reconnect timer fires', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon
+        .stub(Amqp.prototype, 'markConnected')
+        .onFirstCall()
+        .throws(new Error('hold initial initialization open'))
+
+      let releaseInitialCleanup: () => void = () => undefined
+      const initialCleanup = new Promise<void>(resolve => {
+        releaseInitialCleanup = resolve
+      })
+      const closeStub = sinon.stub(Amqp.prototype, 'close')
+      closeStub.onFirstCall().returns(initialCleanup)
+      closeStub.resolves()
+
+      await helper.load(
+        [amqpOut, amqpBroker],
+        amqpOutFlowFixture,
+        credentialsFixture,
+      )
+
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      await onConnClose()
+      await clock.tickAsync(2001)
+
+      await onConnClose()
+      await clock.tickAsync(4001)
+
+      releaseInitialCleanup()
+      await clock.tickAsync(0)
+
+      expect(connectStub.callCount).to.equal(2)
+      expect(initializeStub.callCount).to.equal(2)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('retries initialization on unclassified connect errors when reconnectOnError is true', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -164,8 +164,7 @@ describe('amqp-out Node', () => {
   });
 
   it('should handle dynamic routing key from `flow` context', async function () {
-    const setRoutingKeyStub = sinon.stub(Amqp.prototype, 'setRoutingKey');
-    sinon.stub(Amqp.prototype, 'publish');
+    const publishStub = sinon.stub(Amqp.prototype, 'publish');
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
     const channelMock = { on: sinon.stub(), off: sinon.stub() }
     sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
@@ -184,14 +183,17 @@ describe('amqp-out Node', () => {
     flowContext.set('myFlowVar', 'flow_routing_key');
     await amqpOutNode.receive({ payload: 'foo' });
 
-    expect(setRoutingKeyStub.calledWith('flow_routing_key')).to.be.true;
+    expect(publishStub.calledWith(
+      'foo',
+      sinon.match.any,
+      'flow_routing_key',
+    )).to.be.true;
   });
 
   it('should handle dynamic routing key from `global` context', function (done) {
-    const setRoutingKeyStub = sinon.stub(Amqp.prototype, 'setRoutingKey');
     const publishStub = sinon.stub(Amqp.prototype, 'publish');
 
-    const flowFixture = [...amqpOutFlowFixture];
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture));
     flowFixture[0].exchangeRoutingKeyType = 'global';
     flowFixture[0].exchangeRoutingKey = 'myGlobalVar';
 
@@ -201,16 +203,17 @@ describe('amqp-out Node', () => {
       amqpOutNode.receive({ payload: 'foo' });
 
       setTimeout(() => {
-        expect(setRoutingKeyStub.calledWith('global_routing_key')).to.be.true;
+        expect(publishStub.calledWith(
+          'foo',
+          sinon.match.any,
+          'global_routing_key',
+        )).to.be.true;
         done();
       }, 50);
     });
   });
 
   it('calls done with error when routing key evaluation path throws', async function () {
-    const setRoutingKeyStub = sinon
-      .stub(Amqp.prototype, 'setRoutingKey')
-      .throws(new Error('routing key evaluation failed'));
     const publishStub = sinon.stub(Amqp.prototype, 'publish');
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() };
     const channelMock = { on: sinon.stub(), off: sinon.stub() };
@@ -222,6 +225,9 @@ describe('amqp-out Node', () => {
     flowFixture[0].exchangeRoutingKey = 'routingKey';
 
     await helper.load([amqpOut, amqpBroker], flowFixture, credentialsFixture);
+    sinon
+      .stub(helper._RED.util, 'evaluateNodeProperty')
+      .throws(new Error('routing key evaluation failed'));
     const amqpOutNode = helper.getNode('n1');
     const callErrors: unknown[] = [];
     amqpOutNode.on('call:error', call => {
@@ -234,14 +240,13 @@ describe('amqp-out Node', () => {
     const doneError = callErrors.find(arg => arg instanceof Error) as Error | undefined;
     expect(doneError).to.not.equal(undefined);
     expect(doneError?.message).to.match(/routing key evaluation failed/i);
-    expect(setRoutingKeyStub.calledOnce).to.be.true;
     expect(publishStub.notCalled).to.be.true;
   });
 
   it('passes object payload to publish without pre-serializing', function (done) {
     const payload = { data: 'test' }
     const publishStub = sinon.stub(Amqp.prototype, 'publish')
-    const flowFixture = [...amqpOutFlowFixture]
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture))
 
     helper.load([amqpOut, amqpBroker], flowFixture, credentialsFixture, function () {
       const amqpOutNode = helper.getNode('n1')
@@ -257,7 +262,7 @@ describe('amqp-out Node', () => {
   it('passes string payload to publish without JSON stringifying', function (done) {
     const payload = 'hello'
     const publishStub = sinon.stub(Amqp.prototype, 'publish')
-    const flowFixture = [...amqpOutFlowFixture]
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture))
 
     helper.load([amqpOut, amqpBroker], flowFixture, credentialsFixture, function () {
       const amqpOutNode = helper.getNode('n1')
@@ -268,6 +273,91 @@ describe('amqp-out Node', () => {
         done()
       }, 50)
     })
+  })
+
+  it('publishes ordinary messages concurrently', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+
+    let releaseFirstPublish: () => void = () => undefined
+    const firstPublishPending = new Promise<void>(resolve => {
+      releaseFirstPublish = resolve
+    })
+    const publishStub = sinon
+      .stub(Amqp.prototype, 'publish')
+      .callsFake((payload: unknown) =>
+        payload === 'first' ? firstPublishPending : Promise.resolve(),
+      )
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+    const node = helper.getNode('n1')
+
+    node.receive({ payload: 'first' })
+    node.receive({ payload: 'second' })
+    await new Promise(resolve => setTimeout(resolve, 20))
+    const callsBeforeFirstConfirm = publishStub.callCount
+
+    releaseFirstPublish()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(callsBeforeFirstConfirm).to.equal(2)
+  })
+
+  it('publishes concurrent routing-key overrides as immutable arguments', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+
+    let releaseFirstPublish: () => void = () => undefined
+    const firstPublishPending = new Promise<void>(resolve => {
+      releaseFirstPublish = resolve
+    })
+    const publishStub = sinon
+      .stub(Amqp.prototype, 'publish')
+      .callsFake((payload: unknown) =>
+        payload === 'first' ? firstPublishPending : Promise.resolve(),
+      )
+
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[0].exchangeRoutingKey = 'configured.route'
+    flow[0].exchangeRoutingKeyType = 'str'
+    await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+    const node = helper.getNode('n1')
+
+    node.receive({ payload: 'first', routingKey: 'route.first' })
+    node.receive({ payload: 'second', routingKey: 'route.second' })
+    await new Promise(resolve => setTimeout(resolve, 20))
+    const callsBeforeFirstConfirm = publishStub.callCount
+
+    releaseFirstPublish()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(callsBeforeFirstConfirm).to.equal(2)
+    expect(publishStub.getCalls().map(call => call.args[2])).to.deep.equal([
+      'route.first',
+      'route.second',
+    ])
   })
 
   it('handles error when switching vhost', async function () {
@@ -479,7 +569,7 @@ describe('amqp-out Node', () => {
       .resolves(Amqp.prototype.connection as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(Amqp.prototype.channel as any)
 
-    const flowFixture = [...amqpOutFlowFixture]
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture))
     // @ts-ignore
     flowFixture[0].exchangeRoutingKeyType = 'msg'
 
@@ -520,7 +610,7 @@ describe('amqp-out Node', () => {
       .resolves(Amqp.prototype.connection as any)
     sinon.stub(Amqp.prototype, 'initialize').resolves(Amqp.prototype.channel as any)
 
-    const flowFixture = [...amqpOutFlowFixture]
+    const flowFixture = JSON.parse(JSON.stringify(amqpOutFlowFixture))
     // @ts-ignore
     flowFixture[0].exchangeRoutingKeyType = 'jsonata'
 
@@ -610,10 +700,15 @@ describe('amqp-out Node', () => {
     const published: Array<{ payload: unknown; routingKey: string }> = []
     sinon
       .stub(Amqp.prototype, 'publish')
-      .callsFake(async function (this: any, payload: unknown) {
+      .callsFake(async function (
+        this: any,
+        payload: unknown,
+        properties: unknown,
+        routingKey: string,
+      ) {
         published.push({
           payload,
-          routingKey: this.config.exchange.routingKey,
+          routingKey,
         })
       })
 
@@ -647,7 +742,7 @@ describe('amqp-out Node', () => {
     ).to.equal('route.b')
   })
 
-  it('restores the configured routing key after a message override', async function () {
+  it('keeps the configured routing key unchanged after a message override', async function () {
     const connectionMock = {
       on: sinon.stub(),
       off: sinon.stub(),
@@ -662,14 +757,21 @@ describe('amqp-out Node', () => {
     sinon.stub(Amqp.prototype, 'close').resolves()
 
     const publishedRoutingKeys: string[] = []
+    const configuredRoutingKeys: string[] = []
     let notifyPublishedTwice: () => void = () => undefined
     const publishedTwice = new Promise<void>(resolve => {
       notifyPublishedTwice = resolve
     })
     sinon
       .stub(Amqp.prototype, 'publish')
-      .callsFake(async function (this: any) {
-        publishedRoutingKeys.push(this.config.exchange.routingKey)
+      .callsFake(async function (
+        this: any,
+        payload: unknown,
+        properties: unknown,
+        routingKey: string,
+      ) {
+        publishedRoutingKeys.push(routingKey)
+        configuredRoutingKeys.push(this.config.exchange.routingKey)
         if (publishedRoutingKeys.length === 2) {
           notifyPublishedTwice()
         }
@@ -690,6 +792,10 @@ describe('amqp-out Node', () => {
 
     expect(publishedRoutingKeys).to.deep.equal([
       'message.route',
+      'configured.route',
+    ])
+    expect(configuredRoutingKeys).to.deep.equal([
+      'configured.route',
       'configured.route',
     ])
   })

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -797,6 +797,103 @@ describe('amqp-out Node', () => {
     expect(newConnection.on.called).to.be.true
   })
 
+  it('keeps startup connection initialization when msg.vhost is unchanged', async function () {
+    let releaseConnection: (connection: unknown) => void = () => undefined
+    const pendingConnection = new Promise(resolve => {
+      releaseConnection = resolve
+    })
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').returns(pendingConnection as any)
+    const initializeStub = sinon
+      .stub(Amqp.prototype, 'initialize')
+      .resolves(channelMock as any)
+    const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    let notifyPublished: () => void = () => undefined
+    const published = new Promise<void>(resolve => {
+      notifyPublished = resolve
+    })
+    sinon.stub(Amqp.prototype, 'publish').callsFake(async () => {
+      notifyPublished()
+    })
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[2].vhost = 'vh1'
+
+    await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({ payload: 'same-vhost', vhost: 'vh1' })
+    releaseConnection(connectionMock)
+    const result = await Promise.race([
+      published.then(() => 'published'),
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 100)),
+    ])
+
+    expect(result).to.equal('published')
+    expect(initializeStub.calledOnce).to.be.true
+    expect(setVhostStub.called).to.be.false
+    expect(connectionMock.on.called).to.be.true
+  })
+
+  it('keeps startup channel initialization when msg.vhost is unchanged', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    let notifyInitializeStarted: () => void = () => undefined
+    const initializeStarted = new Promise<void>(resolve => {
+      notifyInitializeStarted = resolve
+    })
+    let releaseInitialization: (channel: unknown) => void = () => undefined
+    const pendingInitialization = new Promise(resolve => {
+      releaseInitialization = resolve
+    })
+    sinon.stub(Amqp.prototype, 'initialize').callsFake(() => {
+      notifyInitializeStarted()
+      return pendingInitialization as any
+    })
+    const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    let notifyPublished: () => void = () => undefined
+    const published = new Promise<void>(resolve => {
+      notifyPublished = resolve
+    })
+    sinon.stub(Amqp.prototype, 'publish').callsFake(async () => {
+      notifyPublished()
+    })
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[2].vhost = 'vh1'
+
+    await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+    await initializeStarted
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({ payload: 'same-vhost', vhost: 'vh1' })
+    releaseInitialization(channelMock)
+    const result = await Promise.race([
+      published.then(() => 'published'),
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 100)),
+    ])
+
+    expect(result).to.equal('published')
+    expect(setVhostStub.called).to.be.false
+    expect(channelMock.on.called).to.be.true
+  })
+
   it('keeps routing keys isolated across concurrent vhost switches', async function () {
     const connectionMock = {
       on: sinon.stub(),

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -666,6 +666,64 @@ describe('amqp-out Node', () => {
     )
   })
 
+  it('waits for and invalidates startup initialization before switching vhost', async function () {
+    let releaseInitialConnect: (connection: unknown) => void = () => undefined
+    const initialConnect = new Promise(resolve => {
+      releaseInitialConnect = resolve
+    })
+    const oldConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const newConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const newChannel = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').returns(initialConnect as any)
+    const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(newChannel as any)
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+    const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
+    sinon.stub(Amqp.prototype, 'getConnection').returns(newConnection as any)
+    sinon.stub(Amqp.prototype, 'getChannel').returns(newChannel as any)
+    sinon.stub(Amqp.prototype, 'markConnected')
+    let notifyPublished: () => void = () => undefined
+    const published = new Promise<void>(resolve => {
+      notifyPublished = resolve
+    })
+    sinon.stub(Amqp.prototype, 'publish').callsFake(async () => {
+      notifyPublished()
+    })
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+    const amqpOutNode = helper.getNode('n1')
+
+    amqpOutNode.receive({ payload: 'switched', vhost: 'new-vhost' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(setVhostStub.called).to.be.false
+
+    releaseInitialConnect(oldConnection)
+    await published
+
+    expect(closeStub.calledOnce).to.be.true
+    expect(initializeStub.called).to.be.false
+    expect(setVhostStub.calledOnceWith('new-vhost')).to.be.true
+    expect(oldConnection.on.called).to.be.false
+    expect(newConnection.on.called).to.be.true
+  })
+
   it('keeps routing keys isolated across concurrent vhost switches', async function () {
     const connectionMock = {
       on: sinon.stub(),

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -666,11 +666,7 @@ describe('amqp-out Node', () => {
     )
   })
 
-  it('waits for and invalidates startup initialization before switching vhost', async function () {
-    let releaseInitialConnect: (connection: unknown) => void = () => undefined
-    const initialConnect = new Promise(resolve => {
-      releaseInitialConnect = resolve
-    })
+  it('cancels a stalled startup connection before switching vhost', async function () {
     const oldConnection = {
       on: sinon.stub(),
       off: sinon.stub(),
@@ -686,7 +682,18 @@ describe('amqp-out Node', () => {
       off: sinon.stub(),
       close: sinon.stub(),
     }
-    sinon.stub(Amqp.prototype, 'connect').returns(initialConnect as any)
+    sinon
+      .stub(Amqp.prototype, 'connect')
+      .callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(new Error('startup connection cancelled')),
+              { once: true },
+            )
+          }) as any,
+      )
     const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(newChannel as any)
     const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
     const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
@@ -709,16 +716,82 @@ describe('amqp-out Node', () => {
     const amqpOutNode = helper.getNode('n1')
 
     amqpOutNode.receive({ payload: 'switched', vhost: 'new-vhost' })
-    await Promise.resolve()
-    await Promise.resolve()
+    const result = await Promise.race([
+      published.then(() => 'published'),
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 100)),
+    ])
 
-    expect(setVhostStub.called).to.be.false
-
-    releaseInitialConnect(oldConnection)
-    await published
-
+    expect(result).to.equal('published')
     expect(closeStub.calledOnce).to.be.true
     expect(initializeStub.called).to.be.false
+    expect(setVhostStub.calledOnceWith('new-vhost')).to.be.true
+    expect(oldConnection.on.called).to.be.false
+    expect(newConnection.on.called).to.be.true
+  })
+
+  it('cancels stalled startup channel creation before switching vhost', async function () {
+    const oldConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const newConnection = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const newChannel = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(oldConnection as any)
+    let notifyInitializationStarted: () => void = () => undefined
+    const initializationStarted = new Promise<void>(resolve => {
+      notifyInitializationStarted = resolve
+    })
+    sinon
+      .stub(Amqp.prototype, 'initialize')
+      .callsFake(
+        (options?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            notifyInitializationStarted()
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(new Error('startup channel creation cancelled')),
+              { once: true },
+            )
+          }) as any,
+      )
+    const closeStub = sinon.stub(Amqp.prototype, 'close').resolves()
+    const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
+    sinon.stub(Amqp.prototype, 'getConnection').returns(newConnection as any)
+    sinon.stub(Amqp.prototype, 'getChannel').returns(newChannel as any)
+    sinon.stub(Amqp.prototype, 'markConnected')
+    let notifyPublished: () => void = () => undefined
+    const published = new Promise<void>(resolve => {
+      notifyPublished = resolve
+    })
+    sinon.stub(Amqp.prototype, 'publish').callsFake(async () => {
+      notifyPublished()
+    })
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+    await initializationStarted
+    const amqpOutNode = helper.getNode('n1')
+
+    amqpOutNode.receive({ payload: 'switched', vhost: 'new-vhost' })
+    const result = await Promise.race([
+      published.then(() => 'published'),
+      new Promise(resolve => setTimeout(() => resolve('timed out'), 100)),
+    ])
+
+    expect(result).to.equal('published')
+    expect(closeStub.calledOnce).to.be.true
     expect(setVhostStub.calledOnceWith('new-vhost')).to.be.true
     expect(oldConnection.on.called).to.be.false
     expect(newConnection.on.called).to.be.true
@@ -1237,6 +1310,66 @@ describe('amqp-out Node', () => {
       await clock.tickAsync(0)
 
       expect(connectStub.calledOnce).to.be.true
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('does not schedule reconnect after an in-progress reconnect close is superseded by a vhost switch', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      const initializeStub = sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      let notifyReconnectCloseStarted: () => void = () => undefined
+      const reconnectCloseStarted = new Promise<void>(resolve => {
+        notifyReconnectCloseStarted = resolve
+      })
+      let releaseReconnectClose: () => void = () => undefined
+      const reconnectClosePending = new Promise<void>(resolve => {
+        releaseReconnectClose = resolve
+      })
+      let closeCallCount = 0
+      sinon.stub(Amqp.prototype, 'close').callsFake(async () => {
+        closeCallCount += 1
+        if (closeCallCount === 1) {
+          notifyReconnectCloseStarted()
+          await reconnectClosePending
+        }
+      })
+      const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
+      let notifyPublished: () => void = () => undefined
+      const published = new Promise<void>(resolve => {
+        notifyPublished = resolve
+      })
+      sinon.stub(Amqp.prototype, 'publish').callsFake(async () => {
+        notifyPublished()
+      })
+      sinon.stub(Amqp.prototype, 'getConnection').returns(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'getChannel').returns(channelMock as any)
+
+      await helper.load(
+        [amqpOut, amqpBroker],
+        amqpOutFlowFixture,
+        credentialsFixture,
+      )
+
+      const onConnClose = connectionMock.on.withArgs('close').getCall(0).args[1]
+      const reconnectOperation = onConnClose()
+      await reconnectCloseStarted
+
+      const amqpOutNode = helper.getNode('n1')
+      amqpOutNode.receive({ payload: 'switched', vhost: 'vh2' })
+      await published
+      expect(setVhostStub.calledOnceWith('vh2')).to.be.true
+
+      releaseReconnectClose()
+      await reconnectOperation
+      await clock.tickAsync(2_001)
+
+      expect(connectStub.calledOnce).to.be.true
+      expect(initializeStub.calledOnce).to.be.true
     } finally {
       clock.restore()
     }

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -576,6 +576,171 @@ describe('amqp-out Node', () => {
     )
   })
 
+  it('keeps routing keys isolated across concurrent vhost switches', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+
+    let notifyFirstSwitchStarted: () => void = () => undefined
+    const firstSwitchStarted = new Promise<void>(resolve => {
+      notifyFirstSwitchStarted = resolve
+    })
+    let releaseFirstSwitch: () => void = () => undefined
+    const firstSwitchPending = new Promise<void>(resolve => {
+      releaseFirstSwitch = resolve
+    })
+    sinon
+      .stub(Amqp.prototype, 'setVhost')
+      .callsFake(async (vhost: string) => {
+        if (vhost === 'vh-a') {
+          notifyFirstSwitchStarted()
+          await firstSwitchPending
+        }
+      })
+
+    const published: Array<{ payload: unknown; routingKey: string }> = []
+    sinon
+      .stub(Amqp.prototype, 'publish')
+      .callsFake(async function (this: any, payload: unknown) {
+        published.push({
+          payload,
+          routingKey: this.config.exchange.routingKey,
+        })
+      })
+
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[0].exchangeRoutingKeyType = 'str'
+    await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({
+      payload: 'message-a',
+      routingKey: 'route.a',
+      vhost: 'vh-a',
+    })
+    await firstSwitchStarted
+
+    amqpOutNode.receive({
+      payload: 'message-b',
+      routingKey: 'route.b',
+      vhost: 'vh-b',
+    })
+    await new Promise(resolve => setTimeout(resolve, 20))
+    releaseFirstSwitch()
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(published).to.have.length(2)
+    expect(
+      published.find(item => item.payload === 'message-a')?.routingKey,
+    ).to.equal('route.a')
+    expect(
+      published.find(item => item.payload === 'message-b')?.routingKey,
+    ).to.equal('route.b')
+  })
+
+  it('restores the configured routing key after a message override', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+
+    const publishedRoutingKeys: string[] = []
+    let notifyPublishedTwice: () => void = () => undefined
+    const publishedTwice = new Promise<void>(resolve => {
+      notifyPublishedTwice = resolve
+    })
+    sinon
+      .stub(Amqp.prototype, 'publish')
+      .callsFake(async function (this: any) {
+        publishedRoutingKeys.push(this.config.exchange.routingKey)
+        if (publishedRoutingKeys.length === 2) {
+          notifyPublishedTwice()
+        }
+      })
+
+    const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+    flow[0].exchangeRoutingKey = 'configured.route'
+    flow[0].exchangeRoutingKeyType = 'str'
+    await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({
+      payload: 'overridden',
+      routingKey: 'message.route',
+    })
+    amqpOutNode.receive({ payload: 'configured' })
+    await publishedTwice
+
+    expect(publishedRoutingKeys).to.deep.equal([
+      'message.route',
+      'configured.route',
+    ])
+  })
+
+  it('does not publish an in-flight vhost switch after the node closes', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    sinon.stub(Amqp.prototype, 'getConnection').returns(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'getChannel').returns(channelMock as any)
+
+    let notifySwitchStarted: () => void = () => undefined
+    const switchStarted = new Promise<void>(resolve => {
+      notifySwitchStarted = resolve
+    })
+    let releaseSwitch: () => void = () => undefined
+    const switchPending = new Promise<void>(resolve => {
+      releaseSwitch = resolve
+    })
+    sinon.stub(Amqp.prototype, 'setVhost').callsFake(async () => {
+      notifySwitchStarted()
+      await switchPending
+    })
+    const publishStub = sinon.stub(Amqp.prototype, 'publish').resolves()
+
+    await helper.load(
+      [amqpOut, amqpBroker],
+      amqpOutFlowFixture,
+      credentialsFixture,
+    )
+
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({ payload: 'must-not-publish', vhost: 'vh2' })
+    await switchStarted
+    await amqpOutNode.close()
+
+    releaseSwitch()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(publishStub.called).to.be.false
+  })
+
   it('removes listeners before switching vhost', function (done) {
     const connectionMock = {
       off: sinon.spy(),
@@ -1124,6 +1289,48 @@ describe('amqp-out Node', () => {
       expect(connectStub.callCount).to.equal(2)
 
       await clock.tickAsync(2000)
+      expect(connectStub.callCount).to.equal(3)
+    } finally {
+      clock.restore()
+    }
+  })
+
+  it('keeps retrying after broker-close recovery fails with reconnectOnError disabled', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const initialConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const recoveredConnection = {
+        on: sinon.stub(),
+        off: sinon.stub(),
+        close: sinon.stub(),
+      }
+      const channelMock = { on: sinon.stub(), off: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect')
+      connectStub.onFirstCall().resolves(initialConnection as any)
+      connectStub
+        .onSecondCall()
+        .rejects(new Error('broker is still restarting'))
+      connectStub.onThirdCall().resolves(recoveredConnection as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+
+      const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+      flow[0].reconnectOnError = false
+
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      const onConnectionClose = initialConnection.on
+        .withArgs('close')
+        .getCall(0).args[1]
+
+      await onConnectionClose()
+      await clock.tickAsync(2001)
+      expect(connectStub.callCount).to.equal(2)
+
+      await clock.tickAsync(4001)
       expect(connectStub.callCount).to.equal(3)
     } finally {
       clock.restore()

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -1450,6 +1450,57 @@ describe('amqp-out Node', () => {
     }
   })
 
+  it('clears a failed-switch reconnect timer before retrying the same vhost', async function () {
+    const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
+    try {
+      const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const channelMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+      const connectStub = sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+      sinon.stub(Amqp.prototype, 'close').resolves()
+      sinon.stub(Amqp.prototype, 'getConnection').returns(connectionMock as any)
+      sinon.stub(Amqp.prototype, 'getChannel').returns(channelMock as any)
+      sinon.stub(Amqp.prototype, 'publish').resolves()
+
+      let requestedVhost = 'vh1'
+      let initializedVhost: string | undefined = 'vh1'
+      sinon.stub(Amqp.prototype, 'getVhost').callsFake(() => requestedVhost)
+      sinon
+        .stub(Amqp.prototype, 'isInitializedForVhost')
+        .callsFake((vhost: string) => initializedVhost === vhost)
+      const setVhostStub = sinon
+        .stub(Amqp.prototype, 'setVhost')
+        .callsFake(async (vhost: string) => {
+          requestedVhost = vhost
+          initializedVhost = undefined
+          if (setVhostStub.calledOnce) {
+            throw new Error('transient switch failure')
+          }
+          initializedVhost = vhost
+        })
+
+      const flow = JSON.parse(JSON.stringify(amqpOutFlowFixture))
+      flow[0].reconnectOnError = true
+      await helper.load([amqpOut, amqpBroker], flow, credentialsFixture)
+      const amqpOutNode = helper.getNode('n1')
+
+      amqpOutNode.receive({ payload: 'first', vhost: 'vh2' })
+      await clock.tickAsync(0)
+      expect(setVhostStub.calledOnce).to.equal(true)
+
+      amqpOutNode.receive({ payload: 'second', vhost: 'vh2' })
+      await clock.tickAsync(0)
+      expect(setVhostStub.calledTwice).to.equal(true)
+      expect(connectStub.calledOnce).to.equal(true)
+
+      await clock.tickAsync(2000)
+
+      expect(connectStub.calledOnce).to.equal(true)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('does not schedule reconnect after an in-progress reconnect close is superseded by a vhost switch', async function () {
     const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true })
     try {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -403,6 +403,42 @@ describe('amqp-out Node', () => {
     expect(publishStub.notCalled).to.be.true;
   });
 
+  it('retries a failed vhost switch when the next message targets the same vhost', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    let requestedVhost = 'vh1'
+    let initializedVhost: string | undefined = 'vh1'
+    sinon.stub(Amqp.prototype, 'getVhost').callsFake(() => requestedVhost)
+    sinon
+      .stub(Amqp.prototype, 'isInitializedForVhost')
+      .callsFake((vhost: string) => initializedVhost === vhost)
+    const setVhostStub = sinon
+      .stub(Amqp.prototype, 'setVhost')
+      .callsFake(async (vhost: string) => {
+        requestedVhost = vhost
+        initializedVhost = undefined
+        if (setVhostStub.calledOnce) {
+          throw new Error('transient switch failure')
+        }
+        initializedVhost = vhost
+      })
+    const publishStub = sinon.stub(Amqp.prototype, 'publish').resolves()
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+
+    amqpOutNode.receive({ payload: 'first', vhost: 'vh2' })
+    await new Promise(resolve => setTimeout(resolve, 20))
+    amqpOutNode.receive({ payload: 'second', vhost: 'vh2' })
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(setVhostStub.calledTwice).to.equal(true)
+    expect(publishStub.calledOnce).to.equal(true)
+    expect(publishStub.firstCall.args[0]).to.equal('second')
+  })
+
   it('calls done with error when publish fails', async function () {
     const publishStub = sinon.stub(Amqp.prototype, 'publish').rejects(new Error('publish failed'));
     const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
@@ -816,6 +852,7 @@ describe('amqp-out Node', () => {
     const initializeStub = sinon
       .stub(Amqp.prototype, 'initialize')
       .resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'isInitializedForVhost').returns(true)
     const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
     sinon.stub(Amqp.prototype, 'close').resolves()
     let notifyPublished: () => void = () => undefined
@@ -867,6 +904,7 @@ describe('amqp-out Node', () => {
       notifyInitializeStarted()
       return pendingInitialization as any
     })
+    sinon.stub(Amqp.prototype, 'isInitializedForVhost').returns(true)
     const setVhostStub = sinon.stub(Amqp.prototype, 'setVhost').resolves()
     sinon.stub(Amqp.prototype, 'close').resolves()
     let notifyPublished: () => void = () => undefined

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -1103,16 +1103,9 @@ describe('amqp-out Node', () => {
     )
 
     const amqpOutNode = helper.getNode('n1')
-    let doneCalls = 0
-    let doneError: Error | undefined
-    ;(amqpOutNode as any)._inputCallback(
-      { payload: 'must-not-publish', vhost: 'vh2' },
-      undefined,
-      (error?: Error) => {
-        doneCalls += 1
-        doneError = error
-      },
-    )
+    const callErrors: unknown[] = []
+    amqpOutNode.on('call:error', call => callErrors.push(call.args[0]))
+    amqpOutNode.receive({ payload: 'must-not-publish', vhost: 'vh2' })
     await switchStarted
     await amqpOutNode.close()
 
@@ -1120,8 +1113,8 @@ describe('amqp-out Node', () => {
     await new Promise(resolve => setTimeout(resolve, 50))
 
     expect(publishStub.called).to.be.false
-    expect(doneCalls).to.equal(1)
-    expect(doneError).to.be.instanceOf(Error)
+    expect(callErrors).to.have.length(1)
+    expect(callErrors[0]).to.be.instanceOf(Error)
   })
 
   it('completes a signal-rejected vhost switch exactly once with an error', async function () {
@@ -1144,18 +1137,15 @@ describe('amqp-out Node', () => {
 
     await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
     const node = helper.getNode('n1')
-    let doneCalls = 0
-    let doneError: Error | undefined
-    ;(node as any)._inputCallback({ payload: 'cancelled', vhost: 'vh2' }, undefined, (error?: Error) => {
-      doneCalls += 1
-      doneError = error
-    })
+    const callErrors: unknown[] = []
+    node.on('call:error', call => callErrors.push(call.args[0]))
+    node.receive({ payload: 'cancelled', vhost: 'vh2' })
     await switchStarted
     await node.close()
     await new Promise(resolve => setTimeout(resolve, 50))
 
-    expect(doneCalls).to.equal(1)
-    expect(doneError).to.be.instanceOf(Error)
+    expect(callErrors).to.have.length(1)
+    expect(callErrors[0]).to.be.instanceOf(Error)
   })
 
   it('aborts a never-settling connection created by a vhost switch on shutdown', async function () {

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -1113,6 +1113,106 @@ describe('amqp-out Node', () => {
     expect(publishStub.called).to.be.false
   })
 
+  it('aborts a never-settling connection created by a vhost switch on shutdown', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    let switchSignal: AbortSignal | undefined
+    let notifySwitchStarted: () => void = () => undefined
+    const switchStarted = new Promise<void>(resolve => {
+      notifySwitchStarted = resolve
+    })
+    let releaseSwitch: () => void = () => undefined
+    const pendingSwitch = new Promise<void>(resolve => {
+      releaseSwitch = resolve
+    })
+    const connectStub = sinon.stub(Amqp.prototype, 'connect')
+    connectStub.onFirstCall().callsFake(function (this: { broker?: unknown }) {
+      this.broker = { vhost: 'vh1' }
+      return Promise.resolve(connectionMock as any)
+    })
+    connectStub.onSecondCall().callsFake((options?: { signal?: AbortSignal }) => {
+      switchSignal = options?.signal
+      notifySwitchStarted()
+      return pendingSwitch as any
+    })
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    sinon.stub(Amqp.prototype, 'isInitializedForVhost').returns(false)
+    const publishStub = sinon.stub(Amqp.prototype, 'publish').resolves()
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({ payload: 'switching', vhost: 'vh2' })
+    await switchStarted
+
+    await amqpOutNode.close()
+    const switchWasAborted = switchSignal?.aborted
+    releaseSwitch()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(switchWasAborted).to.equal(true)
+    expect(publishStub.called).to.equal(false)
+  })
+
+  it('aborts never-settling channel creation created by a vhost switch on shutdown', async function () {
+    const connectionMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    const channelMock = {
+      on: sinon.stub(),
+      off: sinon.stub(),
+      close: sinon.stub(),
+    }
+    sinon
+      .stub(Amqp.prototype, 'connect')
+      .callsFake(function (this: { broker?: unknown }) {
+        this.broker = { vhost: 'vh1' }
+        return Promise.resolve(connectionMock as any)
+      })
+    let switchSignal: AbortSignal | undefined
+    let notifySwitchStarted: () => void = () => undefined
+    const switchStarted = new Promise<void>(resolve => {
+      notifySwitchStarted = resolve
+    })
+    let releaseSwitch: () => void = () => undefined
+    const pendingSwitch = new Promise<void>(resolve => {
+      releaseSwitch = resolve
+    })
+    const initializeStub = sinon.stub(Amqp.prototype, 'initialize')
+    initializeStub.onFirstCall().resolves(channelMock as any)
+    initializeStub.onSecondCall().callsFake((options?: { signal?: AbortSignal }) => {
+      switchSignal = options?.signal
+      notifySwitchStarted()
+      return pendingSwitch as any
+    })
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    sinon.stub(Amqp.prototype, 'isInitializedForVhost').returns(false)
+    const publishStub = sinon.stub(Amqp.prototype, 'publish').resolves()
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const amqpOutNode = helper.getNode('n1')
+    amqpOutNode.receive({ payload: 'switching', vhost: 'vh2' })
+    await switchStarted
+
+    await amqpOutNode.close()
+    const switchWasAborted = switchSignal?.aborted
+    releaseSwitch()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(switchWasAborted).to.equal(true)
+    expect(publishStub.called).to.equal(false)
+  })
+
   it('removes listeners before switching vhost', function (done) {
     const connectionMock = {
       off: sinon.spy(),

--- a/test/nodes/amqp-out.spec.ts
+++ b/test/nodes/amqp-out.spec.ts
@@ -1103,14 +1103,59 @@ describe('amqp-out Node', () => {
     )
 
     const amqpOutNode = helper.getNode('n1')
-    amqpOutNode.receive({ payload: 'must-not-publish', vhost: 'vh2' })
+    let doneCalls = 0
+    let doneError: Error | undefined
+    ;(amqpOutNode as any)._inputCallback(
+      { payload: 'must-not-publish', vhost: 'vh2' },
+      undefined,
+      (error?: Error) => {
+        doneCalls += 1
+        doneError = error
+      },
+    )
     await switchStarted
     await amqpOutNode.close()
 
     releaseSwitch()
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise(resolve => setTimeout(resolve, 50))
 
     expect(publishStub.called).to.be.false
+    expect(doneCalls).to.equal(1)
+    expect(doneError).to.be.instanceOf(Error)
+  })
+
+  it('completes a signal-rejected vhost switch exactly once with an error', async function () {
+    const connectionMock = { on: sinon.stub(), off: sinon.stub(), close: sinon.stub() }
+    const channelMock = { on: sinon.stub(), off: sinon.stub() }
+    sinon.stub(Amqp.prototype, 'connect').resolves(connectionMock as any)
+    sinon.stub(Amqp.prototype, 'initialize').resolves(channelMock as any)
+    sinon.stub(Amqp.prototype, 'close').resolves()
+    sinon.stub(Amqp.prototype, 'isInitializedForVhost').returns(false)
+    let notifySwitchStarted: () => void = () => undefined
+    const switchStarted = new Promise<void>(resolve => {
+      notifySwitchStarted = resolve
+    })
+    sinon.stub(Amqp.prototype, 'setVhost').callsFake(async (_vhost, options?: { signal?: AbortSignal }) => {
+      notifySwitchStarted()
+      await new Promise<void>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true })
+      })
+    })
+
+    await helper.load([amqpOut, amqpBroker], amqpOutFlowFixture, credentialsFixture)
+    const node = helper.getNode('n1')
+    let doneCalls = 0
+    let doneError: Error | undefined
+    ;(node as any)._inputCallback({ payload: 'cancelled', vhost: 'vh2' }, undefined, (error?: Error) => {
+      doneCalls += 1
+      doneError = error
+    })
+    await switchStarted
+    await node.close()
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(doneCalls).to.equal(1)
+    expect(doneError).to.be.instanceOf(Error)
   })
 
   it('aborts a never-settling connection created by a vhost switch on shutdown', async function () {

--- a/test/nodes/flow-close-tracker.spec.ts
+++ b/test/nodes/flow-close-tracker.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'events'
+import trackTerminalClose from '../../src/nodes/flow-close-tracker'
+
+describe('flow close tracker', () => {
+  it('removes bindings for a runtime child of a changed subflow instance', () => {
+    const events = new EventEmitter()
+    const terminalClose = trackTerminalClose(
+      { events } as never,
+      'subflow-instance-template-amqp-in',
+    )
+
+    events.emit('flows:stopping', {
+      diff: { changed: ['subflow-instance'], removed: [] },
+    })
+
+    expect(terminalClose.shouldRemoveBindings(false)).to.be.true
+    terminalClose.dispose()
+  })
+
+  it('does not match an unrelated subflow instance with a similar prefix', () => {
+    const events = new EventEmitter()
+    const terminalClose = trackTerminalClose(
+      { events } as never,
+      'subflow-instance2-template-amqp-in',
+    )
+
+    events.emit('flows:stopping', {
+      diff: { changed: ['subflow-instance'], removed: [] },
+    })
+
+    expect(terminalClose.shouldRemoveBindings(false)).to.be.false
+    terminalClose.dispose()
+  })
+})

--- a/test/nodes/flow-close-tracker.spec.ts
+++ b/test/nodes/flow-close-tracker.spec.ts
@@ -7,7 +7,10 @@ describe('flow close tracker', () => {
     const events = new EventEmitter()
     const terminalClose = trackTerminalClose(
       { events } as never,
-      'subflow-instance-template-amqp-in',
+      {
+        id: 'subflow-instance-template-amqp-in',
+        _flow: { TYPE: 'subflow', id: 'subflow-instance' },
+      } as never,
     )
 
     events.emit('flows:stopping', {
@@ -18,15 +21,18 @@ describe('flow close tracker', () => {
     terminalClose.dispose()
   })
 
-  it('does not match an unrelated subflow instance with a similar prefix', () => {
+  it('does not treat an arbitrarily prefixed node as a subflow child', () => {
     const events = new EventEmitter()
     const terminalClose = trackTerminalClose(
       { events } as never,
-      'subflow-instance2-template-amqp-in',
+      {
+        id: 'abc-def',
+        _flow: { TYPE: 'flow', id: 'flow-1' },
+      } as never,
     )
 
     events.emit('flows:stopping', {
-      diff: { changed: ['subflow-instance'], removed: [] },
+      diff: { changed: ['abc'], removed: [] },
     })
 
     expect(terminalClose.shouldRemoveBindings(false)).to.be.false


### PR DESCRIPTION
## Summary

### RabbitMQ recovery

- Reconnect after broker connection closes, channel closes, or consumer cancellation, including RabbitMQ restarts and updates, regardless of `reconnectOnError` (that option still controls error-event recovery).
- Keep retrying failed broker-close recovery with bounded backoff, coalesce concurrent reconnect triggers through the timer-to-initialization handoff so duplicate channels and consumers cannot be queued, and cancel pending recovery during shutdown or vhost changes.
- Invalidate stale initialization attempts so reconnects during startup cannot register duplicate consumers or mark an obsolete channel connected, make connect/channel initialization abortable across all three node types, abort stalled input-node initialization as soon as manual or event-driven reconnect increments the lifecycle version, reject queued input-node reconnect initialization whose captured version was superseded by shutdown, and immediately close channels whose asynchronous creation finishes after their lifecycle was invalidated.
- Recover manual-ack input and output nodes independently when they share one pooled connection.
- Preserve durable named-queue bindings during reconnects, but remove old configured bindings for Node-RED `diff.changed` reconfiguration and deletion, including runtime AMQP children whose actual Node-RED `_flow` ownership belongs to changed or removed subflow instances; never infer subflow ownership from node-ID prefixes; if reconnect already closed the resources, temporarily reopen a guarded cleanup channel so terminal removal still succeeds.
- Retry terminal binding cleanup within the same Node-RED close lifecycle, including transient connection, channel creation, and unbind failures; use a cleanup-only channel without asserting obsolete exchange or queue topology, treat AMQP `NOT_FOUND` as already clean, reopen fresh resources for up to three total attempts, release every temporary resource between attempts, and retain the last failure as the cause when cleanup is exhausted.

### Shared node lifecycle coordinator

- Centralize startup, queued initialization, cancellation ownership, reconnect coalescing, exponential backoff, shutdown, stale-generation rejection, and resource replacement in one `AmqpLifecycleCoordinator` used by output, input, and manual-ack input nodes.
- Extract shared input-node lifecycle wiring into `src/nodes/amqp-input-lifecycle.ts`, so `amqp-in` and `amqp-in-manual-ack` retain only their message-specific reconnect or settlement behavior while sharing listener setup, error classification, initialization, reconnect reporting, and terminal shutdown.
- Extract manual-delivery settlement and hidden-token ownership into src/delivery-settlement-tracker.ts, isolating token lookup, channel ownership checks, and ack/nack cleanup from transport pooling, publishing, RPC, and topology code.
- Keep node-specific AMQP setup and event/error reporting in the node adapters while routing startup, reconnect, and dynamic-vhost switching through the same abortable attempt contract.
- Make dynamic-vhost replacement supersede pending recovery, await the active attempt, use the coordinator-owned abort signal for connection and channel creation, reject stale late completion, and release lifecycle ownership during shutdown.
### Connection and channel lifecycle

- Make pooled connection creation single-flight only within the same broker endpoint generation, including host and credentials; track active waiters, promote a raw connection into the pool only when a caller accepts ownership, evict the exact unaccepted pending entry as soon as its final waiter times out so later reconnects can start fresh, close any eventual late connection through its retained settlement handler, and retain the exact generation key on each owner for release.
- Keep pooled connection attempts policy-neutral and apply one five-second overall deadline from terminal close entry across existing-close completion, RPC-consumer detachment, active and reopened unbinds, connection admission, channel creation, channel close, and pooled connection release; retries receive only the remaining budget, teardown is still attempted after earlier timeouts, and a stalled shared attempt is awaited once rather than three times.
- Evict dead pooled connections and release only the exact pooled connection owned by an instance; closing, reconnecting, or switching vhost before initial connection ownership is established performs no pool decrement and cannot dereference a missing entry.
- Preserve separate channels per AMQP node so manual acknowledgments and publishing cannot interfere with each other.
- Remove listeners and broker-node state reliably during reconnect, redeploy, and deletion.

### Manual acknowledgments

- Preserve the original AMQP delivery across Node-RED message cloning through an opaque delivery token.
- Prevent acknowledgments from being applied to a replacement channel after reconnect and reject duplicate settlement attempts.
- Surface failed `ack`, `nack`, `nackAll`, and `reject` operations to the Node-RED message completion callback.
- Treat `payload.reconnectCall` as a control message only when the message is not a real AMQP delivery, so business payloads with that property are still acknowledged normally.

### Publishing and output nodes

- Serialize object and primitive payloads consistently while preserving `Buffer` and `Uint8Array` payloads.
- Enforce publisher backpressure with one shared channel drain gate: later publishes wait before writing, repeated saturation admits one queued write at a time, and channel close/error rejects every waiter without duplicate listeners.
- Preserve mandatory publishing without confirms and continue reporting its returns as warnings, while confirm-enabled mandatory publishes reject with attributable return errors.
- Attribute publisher acknowledgments and nacks through each publish callback, and report accurate successful and failed routing keys when a multi-route publish only partially succeeds.
- Pass routing keys as immutable per-publish arguments so ordinary and overridden output traffic remains concurrent; serialize only vhost mutations, make startup/reconnect and dynamic-vhost connection/channel initialization abortable, discard queued reconnect initializations whose version was superseded, make reconnect recheck its captured generation and scheduled state immediately after an in-flight close, and track requested versus successfully initialized vhosts separately. Preserve and await valid startup/reconnect initialization for unchanged healthy vhosts; require a live connection and channel before treating a target vhost as unchanged; retry a failed switch when the next message targets the same vhost; make that direct retry cancel its obsolete reconnect timer and invalidate queued recovery before taking ownership; clean partially created switch resources; cancel then await the shared initialization coordinator for actual changes; prevent stale old-vhost attempts from overwriting or leaking the switched connection/channel; prevent publishes from crossing connection switches; and register dynamic switches in the shared lifecycle coordinator so shutdown aborts never-settling switch connection or channel creation and prevents late ownership, complete every cancelled or stale unpublished vhost message exactly once with an error, suppress expected signal-aborted switch logging, and prevent in-flight vhost switches from publishing after shutdown.

### RPC

- Share one reply consumer per connection/reply queue across concurrent requests and separate AMQP instances.
- Route responses by correlation ID without losing replies intended for another pending request.
- Track unmatched RPC responses as one capped consumer-level count without retaining or echoing peer-supplied correlation IDs, avoiding per-request O(N×M) diagnostic growth.
- Give queued RPC writes a cancellable admission deadline using the configured RPC timeout; expiry removes the queued write and cleans its reply consumer so it cannot publish later, while successful publication cancels admission and starts a fresh response timeout.
- Report in-flight RPC requests as interrupted when reconnect closes their channel, clean up consumers and timeouts after responses, failures, or cancellation, and wait for stale reply-queue deletion before creating a replacement consumer.

## Testing

- Added regression coverage for reconnect/retry lifecycle including queued-initialization races across all three nodes including input reconnect work queued past shutdown and manual recovery from non-settling connection/channel initialization, durable-binding cleanup after changed-node deploys, changed subflow-instance deploys and arbitrary similarly-prefixed imported node IDs, already-closed deletion, stalled cleanup operations at active unbind, connection admission, channel creation, channel close, and connection release with one overall budget below Node-RED's close timeout, normal connection timeout isolation, mixed cleanup/normal single-flight timeout policies, late unowned connection disposal, poisoned pending-attempt eviction and subsequent fresh reconnect, pre-ownership shutdown and vhost switching, and endpoint-generation isolation after host or credential changes, and single-lifecycle binding cleanup retries after connection, channel creation, active-channel, or reopened-channel failures plus explicit exhaustion failure, cleanup without obsolete topology assertion, missing-topology handling, shared mixed flows, pooled connections, cloned and stale manual-ack deliveries, output routing, dynamic-vhost versus startup/reconnect initialization ownership races including unchanged healthy vhosts, failed-switch retries to the same target with partial-resource cleanup and cancellation of obsolete reconnect timers/queued recovery, coordinator-level replacement cancellation/coalescing, done(error)-exactly-once cancellation contracts, expected-abort logging suppression, and shutdown during non-settling dynamic-switch connection and channel creation, non-settling startup connection/channel creation, reconnects still inside close, and shutdown races, shared/repeated publisher backpressure and mandatory returns, partial multi-route delivery, concurrent/shared RPC replies, cancellable RPC admission behind backpressure with no late publish, deferred response-timeout start after publication, and bounded unmatched-response diagnostics.
- `npm test`: 334 passing
- `npm run lint`: passing
- `npm run test:cov`: passing (95.86% statements, 83.19% branches, 96.90% lines)











### Breaking-change warning: manual acknowledgements

Manual acknowledgements now require Node-RED’s hidden delivery token to survive message cloning. Flows that JSON-serialize, externally persist, or manually reconstruct acknowledgement messages can no longer settle them using only `deliveryTag`; settlement fails locally because the original channel-owned delivery cannot be identified. Consumers with those patterns must preserve the original Node-RED message object/token or redesign persistence before upgrading.